### PR TITLE
test: add structured test stubs for corpus_manager, cli, project_config, and collectors

### DIFF
--- a/CorpusBuilderApp/tests/integration/test_multi_collector_flow.py
+++ b/CorpusBuilderApp/tests/integration/test_multi_collector_flow.py
@@ -1,0 +1,12 @@
+import pytest
+from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from CryptoFinanceCorpusBuilder.shared_tools.collectors.fred_collector import FREDCollector
+from CryptoFinanceCorpusBuilder.shared_tools.collectors.github_collector import GitHubCollector
+
+@pytest.mark.skip("Audit stub – implement later")
+def test_run_fred_and_github_collectors(monkeypatch, tmp_path):
+    """Run collectors sequentially using mocked APIs."""
+    # TODO: create ProjectConfig pointing corpus_dir to tmp_path
+    # TODO: monkeypatch network calls for FREDCollector and GitHubCollector
+    # TODO: execute collectors and verify output files in corpus manager
+    pass

--- a/CorpusBuilderApp/tests/integration/test_project_config_edges.py
+++ b/CorpusBuilderApp/tests/integration/test_project_config_edges.py
@@ -1,0 +1,17 @@
+import pytest
+from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+
+@pytest.mark.skip("Audit stub – implement later")
+def test_load_minimal_config(tmp_path):
+    """Load config with minimal fields and verify defaults."""
+    # TODO: write minimal YAML into tmp_path / 'config.yaml'
+    # TODO: invoke ProjectConfig on that file
+    # TODO: assert directories created and defaults applied
+    pass
+
+@pytest.mark.skip("Audit stub – implement later")
+def test_env_variable_override(monkeypatch, tmp_path):
+    """Environment variables should override YAML paths."""
+    # TODO: set env vars like FRED_API_KEY
+    # TODO: load config and confirm overrides
+    pass

--- a/CorpusBuilderApp/tests/ui/test_collectors_tab_integration.py
+++ b/CorpusBuilderApp/tests/ui/test_collectors_tab_integration.py
@@ -1,0 +1,10 @@
+import pytest
+from PySide6.QtWidgets import QApplication
+from app.ui.tabs.collectors_tab import CollectorsTab
+
+@pytest.mark.skip("Audit stub – implement later")
+def test_collectors_tab_sequential_flow(qtbot, monkeypatch):
+    """Verify tab signals integrate across multiple collectors."""
+    # TODO: create mock ProjectConfig and collectors
+    # TODO: trigger start/stop via UI and assert status updates
+    pass

--- a/CorpusBuilderApp/tests/unit/test_cli_consolidate.py
+++ b/CorpusBuilderApp/tests/unit/test_cli_consolidate.py
@@ -1,0 +1,17 @@
+import pytest
+from CryptoFinanceCorpusBuilder.shared_tools.cli import consolidate_corpus
+
+@pytest.mark.skip("Audit stub – implement later")
+def test_cli_argument_parsing(monkeypatch):
+    """Ensure CLI parses arguments correctly."""
+    # TODO: monkeypatch sys.argv to simulate command line
+    # TODO: call consolidate_corpus.main and verify called with args
+    pass
+
+@pytest.mark.skip("Audit stub – implement later")
+def test_cli_consolidation_flow(tmp_path, monkeypatch):
+    """Run consolidate_corpus with temp dirs and check output."""
+    # TODO: create dummy ProjectConfig YAML under tmp_path
+    # TODO: monkeypatch DomainClassifier and file operations
+    # TODO: assert output stats structure
+    pass

--- a/CorpusBuilderApp/tests/unit/test_corpus_manager.py
+++ b/CorpusBuilderApp/tests/unit/test_corpus_manager.py
@@ -1,0 +1,17 @@
+import pytest
+from CryptoFinanceCorpusBuilder.shared_tools.storage.corpus_manager import CorpusManager
+
+@pytest.mark.skip("Audit stub – implement later")
+def test_add_document_with_sample_metadata(tmp_path):
+    """Ensure documents are added and metadata updated."""
+    # TODO: create sample text/PDF file under tmp_path
+    # TODO: initialize CorpusManager pointing to tmp_path
+    # TODO: call add_document and assert metadata file updated
+    pass
+
+@pytest.mark.skip("Audit stub – implement later")
+def test_get_corpus_stats_empty(tmp_path):
+    """Verify stats structure when corpus is empty."""
+    # TODO: initialize CorpusManager with empty dirs
+    # TODO: call get_corpus_stats and compare to expected defaults
+    pass


### PR DESCRIPTION
## Summary
- add audit test stubs covering corpus manager and CLI
- add skeleton integration tests for project config edges and multi-collector flow
- add UI integration stub for collectors tab

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6843052935ec832693e7fc7e3f681609