### PR TITLE
Add tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            CorpusBuilderApp/requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r CorpusBuilderApp/requirements.txt
+      - name: Run tests
+        working-directory: CorpusBuilderApp
+        run: |
+          if python - <<'PY'
+import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec('coverage') else 1)
+PY
+          then
+            coverage run -m pytest -m "not skip"
+            coverage report
+          else
+            pytest -m "not skip"
+          fi

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # codex_try
+
+[![Tests](https://github.com/OWNER/REPO/actions/workflows/test.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/test.yml)


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest on push & PR
- cache pip deps and use Python 3.12
- run tests from the CorpusBuilderApp directory
- update README with CI badge

## Testing
- `pytest -m "not skip" -c CorpusBuilderApp/pytest.ini` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_68432b72f3d48326956887df2eeeed4d