### PR TITLE
feat: PySide6-compliant CollectorCard UI + full CollectorsTab refactor

### DIFF
--- a/CorpusBuilderApp/app/resources/styles/theme_dark.qss
+++ b/CorpusBuilderApp/app/resources/styles/theme_dark.qss
@@ -136,6 +136,21 @@ QFrame[objectName="card"], QWidget[objectName="card"], QFrame[objectName="chart-
     box-shadow: 0 4px 6px -1px rgba(0,0,0,0.10), 0 8px 25px -5px rgba(0,0,0,0.20);
     transition: box-shadow 0.2s, border-color 0.2s;
 }
+
+QFrame[objectName="collector-card"][status="running"] {
+    border: 2px solid #10b981;
+}
+QFrame[objectName="collector-card"][status="stopped"] {
+    border: 2px solid #6b7280;
+}
+QFrame[objectName="collector-card"][status="error"] {
+    border: 2px solid #ef4444;
+}
+QLabel[objectName="status-dot"] {
+    width: 10px;
+    height: 10px;
+    border-radius: 5px;
+}
 QFrame[objectName="card"]:hover, QWidget[objectName="card"]:hover {
     border-color: #374151;
     box-shadow: 0 8px 25px -5px rgba(0,0,0,0.25), 0 12px 40px -8px rgba(6,182,212,0.10);

--- a/CorpusBuilderApp/app/resources/styles/theme_light.qss
+++ b/CorpusBuilderApp/app/resources/styles/theme_light.qss
@@ -87,6 +87,20 @@ QFrame[objectName="card"], QWidget[objectName="card"] {
     padding: 16px;
     margin-bottom: 16px;
 }
+QFrame[objectName="collector-card"][status="running"] {
+    border: 2px solid #10b981;
+}
+QFrame[objectName="collector-card"][status="stopped"] {
+    border: 2px solid #6b7280;
+}
+QFrame[objectName="collector-card"][status="error"] {
+    border: 2px solid #ef4444;
+}
+QLabel[objectName="status-dot"] {
+    width: 10px;
+    height: 10px;
+    border-radius: 5px;
+}
 
 /* Labels */
 QLabel[objectName="status-info"] {

--- a/CorpusBuilderApp/tests/ui/test_collectors_tab.py
+++ b/CorpusBuilderApp/tests/ui/test_collectors_tab.py
@@ -1,141 +1,67 @@
-# File: tests/ui/test_collectors_tab.py
-
 import pytest
 from unittest.mock import MagicMock, patch
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication
 
 from app.ui.tabs.collectors_tab import CollectorsTab
-from shared_tools.ui_wrappers.collectors.isda_wrapper import ISDAWrapper
 
-class TestCollectorsTab:
-    """UI tests for the CollectorsTab class."""
-    
-    @pytest.fixture
-    def mock_project_config(self):
-        """Create a mock project config."""
-        config = MagicMock()
-        return config
-    
-    @pytest.fixture
-    def app(self, qtbot):
-        """Create a QApplication instance."""
-        return QApplication.instance() or QApplication([])
-    
-    @pytest.fixture
-    def collectors_tab(self, qtbot, mock_project_config, app):
-        """Create a CollectorsTab instance with mocked collectors."""
-        with patch('shared_tools.ui_wrappers.collectors.annas_archive_wrapper.AnnasArchiveWrapper') as mock_anna, \
-             patch('app.ui.tabs.collectors_tab.ISDAWrapper') as mock_isda, \
-             patch('app.ui.tabs.collectors_tab.GitHubWrapper') as mock_github:
-            
-            # Configure mocks
-            mock_isda.return_value = MagicMock()
-            mock_github.return_value = MagicMock()
-            mock_anna.return_value = MagicMock()
-            
-            tab = CollectorsTab(mock_project_config)
-            qtbot.addWidget(tab)
-            yield tab
-    
-    def test_tab_initialization(self, collectors_tab):
-        """Test that the tab initializes correctly."""
-        # Check that the tab has the expected collector tabs
-        assert collectors_tab.collector_tabs.count() >= 3
-        assert collectors_tab.collector_tabs.tabText(0) == "ISDA"
-        assert collectors_tab.collector_tabs.tabText(1) == "GitHub"
-        
-        # Check that the collector wrappers were initialized
-        assert 'isda' in collectors_tab.collector_wrappers
-        assert 'github' in collectors_tab.collector_wrappers
-        assert 'anna' in collectors_tab.collector_wrappers
-    
-    def test_isda_collection_start(self, collectors_tab, qtbot):
-        """Test starting ISDA collection."""
-        # Setup mock collector
-        isda_wrapper = collectors_tab.collector_wrappers['isda']
-        
-        # Set keywords in the UI
-        collectors_tab.isda_keywords.setText("derivatives, protocol")
-        
-        # Set max sources in the UI
-        collectors_tab.isda_max_sources.setValue(30)
-        
-        # Click the start button
-        qtbot.mouseClick(collectors_tab.isda_start_btn, Qt.MouseButton.LeftButton)
-        
-        # Check that the wrapper was called with correct parameters
-        isda_wrapper.set_search_keywords.assert_called_once()
-        assert isda_wrapper.set_search_keywords.call_args[0][0] == ["derivatives", "protocol"]
-        isda_wrapper.set_max_sources.assert_called_once_with(30)
-        isda_wrapper.start.assert_called_once()
-        
-        # Check that UI state was updated
-        assert not collectors_tab.isda_start_btn.isEnabled()
-        assert collectors_tab.isda_stop_btn.isEnabled()
-    
-    def test_isda_collection_stop(self, collectors_tab, qtbot):
-        """Test stopping ISDA collection."""
-        # Setup mock collector
-        isda_wrapper = collectors_tab.collector_wrappers['isda']
-        
-        # Simulate collection in progress
-        collectors_tab.isda_start_btn.setEnabled(False)
-        collectors_tab.isda_stop_btn.setEnabled(True)
-        
-        # Click the stop button
-        qtbot.mouseClick(collectors_tab.isda_stop_btn, Qt.MouseButton.LeftButton)
-        
-        # Check that the wrapper's stop method was called
-        isda_wrapper.stop.assert_called_once()
-        
-        # Check that UI state was updated
-        assert collectors_tab.isda_start_btn.isEnabled()
-        assert not collectors_tab.isda_stop_btn.isEnabled()
-    
-    def test_stop_all_collectors(self, collectors_tab, qtbot):
-        """Test stopping all collectors."""
-        # Setup mock collectors
-        isda_wrapper = collectors_tab.collector_wrappers['isda']
-        github_wrapper = collectors_tab.collector_wrappers['github']
-        anna_wrapper = collectors_tab.collector_wrappers['anna']
-        
-        # Simulate collection in progress
-        collectors_tab.isda_start_btn.setEnabled(False)
-        collectors_tab.isda_stop_btn.setEnabled(True)
-        collectors_tab.github_start_btn.setEnabled(False)
-        collectors_tab.github_stop_btn.setEnabled(True)
-        
-        # Click the stop all button
-        qtbot.mouseClick(collectors_tab.stop_all_btn, Qt.MouseButton.LeftButton)
-        
-        # Check that all wrappers' stop methods were called
-        isda_wrapper.stop.assert_called_once()
-        github_wrapper.stop.assert_called_once()
-        anna_wrapper.stop.assert_called_once()
-        
-        # Check that UI state was updated
-        assert collectors_tab.isda_start_btn.isEnabled()
-        assert not collectors_tab.isda_stop_btn.isEnabled()
-        assert collectors_tab.github_start_btn.isEnabled()
-        assert not collectors_tab.github_stop_btn.isEnabled()
-        
-        # Check that status was updated
-        assert "stopped" in collectors_tab.collection_status_label.text().lower()
-    
-    def test_collection_completed_handler(self, collectors_tab):
-        """Test handling of collection completion."""
-        # Simulate collection in progress
-        collectors_tab.isda_start_btn.setEnabled(False)
-        collectors_tab.isda_stop_btn.setEnabled(True)
-        
-        # Simulate completion signal
-        results = {'documents': [{'id': 1, 'title': 'Doc 1'}, {'id': 2, 'title': 'Doc 2'}]}
-        collectors_tab.on_isda_collection_completed(results)
-        
-        # Check that UI state was updated
-        assert collectors_tab.isda_start_btn.isEnabled()
-        assert not collectors_tab.isda_stop_btn.isEnabled()
-        
-        # Check that status was updated
-        assert "2 documents" in collectors_tab.collection_status_label.text()
+
+@pytest.fixture
+def mock_project_config():
+    return MagicMock()
+
+
+@pytest.fixture
+def collectors_tab(qtbot, mock_project_config):
+    with patch('app.ui.tabs.collectors_tab.ISDAWrapper') as mock_isda, \
+         patch('app.ui.tabs.collectors_tab.GitHubWrapper') as mock_github, \
+         patch('shared_tools.ui_wrappers.collectors.annas_archive_wrapper.AnnasArchiveWrapper') as mock_anna:
+        mock_isda.return_value = MagicMock()
+        mock_github.return_value = MagicMock()
+        mock_anna.return_value = MagicMock()
+        tab = CollectorsTab(mock_project_config)
+        qtbot.addWidget(tab)
+        yield tab
+
+
+def test_tab_initialization(collectors_tab):
+    assert 'isda' in collectors_tab.cards
+    assert 'github' in collectors_tab.cards
+
+
+def test_isda_collection_start(collectors_tab, qtbot):
+    card = collectors_tab.cards['isda']
+    wrapper = collectors_tab.collector_wrappers['isda']
+    qtbot.mouseClick(card.start_btn, Qt.MouseButton.LeftButton)
+    wrapper.start.assert_called_once()
+    assert not card.start_btn.isEnabled()
+    assert card.stop_btn.isEnabled()
+
+
+def test_isda_collection_stop(collectors_tab, qtbot):
+    card = collectors_tab.cards['isda']
+    wrapper = collectors_tab.collector_wrappers['isda']
+    card.start_btn.setEnabled(False)
+    card.stop_btn.setEnabled(True)
+    qtbot.mouseClick(card.stop_btn, Qt.MouseButton.LeftButton)
+    wrapper.stop.assert_called_once()
+    assert card.start_btn.isEnabled()
+    assert not card.stop_btn.isEnabled()
+
+
+def test_handle_signals_update_card(collectors_tab):
+    card = collectors_tab.cards['isda']
+    collectors_tab._handle_progress('isda', 50)
+    assert card.progress_bar.value() == 50
+    collectors_tab._handle_status('isda', 'Running')
+    assert not card.start_btn.isEnabled()
+    assert card.stop_btn.isEnabled()
+
+
+def test_collection_completed_handler(collectors_tab):
+    card = collectors_tab.cards['isda']
+    results = {'docs': 2}
+    collectors_tab.on_collection_completed('isda', results)
+    assert card.start_btn.isEnabled()
+    assert not card.stop_btn.isEnabled()
+    assert 'completed' in collectors_tab.collection_status_label.text().lower()


### PR DESCRIPTION
## Summary
- implement CollectorCard widget with PySide6 signals
- refactor CollectorsTab to use CollectorCard and PySide6
- style collector cards in both dark and light themes
- update UI tests to target CollectorCard interface

## Testing
- `coverage run -m pytest -q` *(fails: ImportError libpulse, aiohttp, pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6843341efbf88326909a2504b11b1e54