### PR TITLE
Refactor corpus and analytics tabs

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/logs_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/logs_tab.py
@@ -1,9 +1,24 @@
-from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QGroupBox,
-                             QLabel, QPushButton, QTextEdit, QComboBox,
-                             QLineEdit, QCheckBox, QFileDialog, QSplitter,
-                             QTableWidget, QTableWidgetItem, QHeaderView)
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QTextEdit,
+    QComboBox,
+    QLineEdit,
+    QCheckBox,
+    QFileDialog,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
+)
 from PySide6.QtCore import Qt, QTimer, Slot as pyqtSlot
 from PySide6.QtGui import QColor, QTextCharFormat, QBrush
+from app.ui.widgets.card_wrapper import CardWrapper
+from app.ui.widgets.section_header import SectionHeader
+from app.ui.widgets.status_dot import StatusDot
 
 import os
 import re
@@ -22,7 +37,10 @@ class LogsTab(QWidget):
         
     def setup_ui(self):
         main_layout = QVBoxLayout(self)
-        
+
+        header = SectionHeader("Logs")
+        main_layout.addWidget(header)
+
         # Log navigation and filtering controls
         controls_layout = QHBoxLayout()
         
@@ -56,7 +74,7 @@ class LogsTab(QWidget):
         
         # Create a splitter for log table and details
         splitter = QSplitter(Qt.Orientation.Vertical)
-        
+
         # Log entries table
         self.log_table = QTableWidget()
         self.log_table.setColumnCount(5)
@@ -68,12 +86,16 @@ class LogsTab(QWidget):
         self.log_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
         self.log_table.clicked.connect(self.on_log_entry_selected)
         
-        splitter.addWidget(self.log_table)
+        table_card = CardWrapper(title="Entries")
+        table_card.body_layout.addWidget(self.log_table)
+        splitter.addWidget(table_card)
         
         # Log detail view
         self.log_detail = QTextEdit()
         self.log_detail.setReadOnly(True)
-        splitter.addWidget(self.log_detail)
+        detail_card = CardWrapper(title="Details")
+        detail_card.body_layout.addWidget(self.log_detail)
+        splitter.addWidget(detail_card)
         
         # Set initial splitter sizes (70% table, 30% details)
         splitter.setSizes([700, 300])
@@ -115,10 +137,7 @@ class LogsTab(QWidget):
         """Scan for log files in the configured log directory"""
         # In a real implementation, this would use project_config to get the log directory
         # For now, use a placeholder path
-        try:
-            log_dir = self.project_config.get_logs_dir()
-        except:
-            log_dir = os.path.expanduser("~/.cryptofinance/logs")
+        log_dir = self.project_config.get_logs_dir()
         
         # Placeholder - in a real implementation this would scan the actual directory
         # For demonstration, populate with sample log files
@@ -383,13 +402,9 @@ class LogsTab(QWidget):
             # Time
             time_item = QTableWidgetItem(entry.get("time", ""))
             self.log_table.setItem(i, 0, time_item)
-            # Level
-            level_item = QTableWidgetItem(entry.get("level", ""))
-            if entry.get("level") == "ERROR":
-                level_item.setForeground(QColor("red"))
-            elif entry.get("level") == "WARNING":
-                level_item.setForeground(QColor("orange"))
-            self.log_table.setItem(i, 1, level_item)
+            # Level with status dot
+            level_widget = StatusDot(entry.get("level", ""), entry.get("level", "").lower())
+            self.log_table.setCellWidget(i, 1, level_widget)
             # Component
             component_item = QTableWidgetItem(entry.get("component", ""))
             self.log_table.setItem(i, 2, component_item)

--- a/CorpusBuilderApp/shared_tools/project_config.py
+++ b/CorpusBuilderApp/shared_tools/project_config.py
@@ -243,8 +243,12 @@ class ProjectConfig:
         """Save configuration to YAML file"""
         with open(self.config_path, 'w') as f:
             yaml.dump(self.config, f, default_flow_style=False)
-    
+
+    def get_logs_dir(self) -> str:
+        """Return the configured logs directory or default path."""
+        return self.get("directories.logs_dir", os.path.expanduser("~/.cryptofinance/logs"))
+
     @classmethod
     def from_yaml(cls, yaml_path: str, environment: Optional[str] = None) -> 'ProjectConfig':
         """Load config from YAML file with schema validation."""
-        return cls(yaml_path, environment=environment) 
+        return cls(yaml_path, environment=environment)

--- a/CorpusBuilderApp/shared_tools/storage/corpus_manager.py
+++ b/CorpusBuilderApp/shared_tools/storage/corpus_manager.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+import os
+import shutil
+from typing import List
+from PySide6.QtCore import QObject, Signal
+
+class CorpusManager(QObject):
+    """Simple corpus manager handling batch file operations."""
+
+    progress_updated = Signal(int, str)
+    status_updated = Signal(str, str)
+    operation_completed = Signal(str)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+
+    # ----------------------------- helpers ---------------------------------
+    def _emit_progress(self, index: int, total: int, op: str) -> None:
+        percent = int((index / total) * 100)
+        self.progress_updated.emit(percent, op)
+
+    def batch_copy_files(self, files: List[str], target_dir: str) -> None:
+        os.makedirs(target_dir, exist_ok=True)
+        total = len(files)
+        for i, src in enumerate(files, 1):
+            try:
+                shutil.copy2(src, target_dir)
+                self.status_updated.emit(src, "success")
+            except Exception:
+                self.status_updated.emit(src, "error")
+            self._emit_progress(i, total, "copy")
+        self.operation_completed.emit("copy")
+
+    def batch_move_files(self, files: List[str], target_dir: str) -> None:
+        os.makedirs(target_dir, exist_ok=True)
+        total = len(files)
+        for i, src in enumerate(files, 1):
+            try:
+                shutil.move(src, target_dir)
+                self.status_updated.emit(src, "success")
+            except Exception:
+                self.status_updated.emit(src, "error")
+            self._emit_progress(i, total, "move")
+        self.operation_completed.emit("move")
+
+    def batch_delete_files(self, files: List[str]) -> None:
+        total = len(files)
+        for i, path in enumerate(files, 1):
+            try:
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+                else:
+                    os.remove(path)
+                self.status_updated.emit(path, "success")
+            except Exception:
+                self.status_updated.emit(path, "error")
+            self._emit_progress(i, total, "delete")
+        self.operation_completed.emit("delete")

--- a/CorpusBuilderApp/tests/ui/test_analytics_tab.py
+++ b/CorpusBuilderApp/tests/ui/test_analytics_tab.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pytest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import Qt
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from app.ui.tabs.analytics_tab import AnalyticsTab
+from app.ui.widgets.card_wrapper import CardWrapper
+from app.ui.widgets.section_header import SectionHeader
+
+
+@pytest.fixture
+def analytics_tab(qapp, mock_project_config, qtbot):
+    tab = AnalyticsTab(mock_project_config)
+    qtbot.addWidget(tab)
+    return tab
+
+
+def test_widgets_present(analytics_tab):
+    headers = analytics_tab.findChildren(SectionHeader)
+    assert any(h.text() == "Analytics" for h in headers)
+    cards = analytics_tab.findChildren(CardWrapper)
+    assert cards
+
+
+def test_filter_signals_trigger_update(monkeypatch, analytics_tab, qtbot):
+    called = []
+    def updated():
+        called.append(True)
+    monkeypatch.setattr(analytics_tab, "update_charts", updated)
+    qtbot.mouseClick(analytics_tab.apply_filters_btn, Qt.MouseButton.LeftButton)
+    assert called

--- a/CorpusBuilderApp/tests/ui/test_logs_tab.py
+++ b/CorpusBuilderApp/tests/ui/test_logs_tab.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import pytest
+from PySide6.QtCore import Qt
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+from app.ui.tabs.logs_tab import LogsTab
+from app.ui.widgets.card_wrapper import CardWrapper
+from app.ui.widgets.section_header import SectionHeader
+from app.ui.widgets.status_dot import StatusDot
+
+
+@pytest.fixture
+def logs_tab(qapp, mock_project_config, qtbot):
+    tab = LogsTab(mock_project_config)
+    qtbot.addWidget(tab)
+    return tab
+
+
+def test_logs_widgets(logs_tab):
+    headers = logs_tab.findChildren(SectionHeader)
+    assert any(h.text() == "Logs" for h in headers)
+    cards = logs_tab.findChildren(CardWrapper)
+    assert cards
+
+
+def test_status_dot_in_table(logs_tab):
+    entry = {"time": "2024", "level": "ERROR", "component": "c", "message": "m", "details": "d"}
+    logs_tab.populate_log_table([entry])
+    widget = logs_tab.log_table.cellWidget(0, 1)
+    assert isinstance(widget, StatusDot)
+    assert widget.label.objectName() == "status--error"


### PR DESCRIPTION
## Summary
- refactor CorpusManagerTab with CardWrapper, SectionHeader, and new CorpusManager
- update AnalyticsTab UI with CardWrapper and scroll support
- refresh LogsTab layout, using CardWrapper and StatusDot
- expose logs directory in ProjectConfig
- add basic UI tests for analytics and logs tabs

## Testing
- `pip install PySide6`
- `pip install pytest-cov`
- `apt-get update`
- `apt-get install -y libegl1`
- `pytest -q CorpusBuilderApp/tests/ui/test_analytics_tab.py CorpusBuilderApp/tests/ui/test_logs_tab.py` *(fails: ImportError, then crashes due to Qt issues)*

------
https://chatgpt.com/codex/tasks/task_e_6843510f30388326abb287e36500c84f