### PR TITLE
Add directory helpers and tests for ProjectConfig

### DIFF
--- a/CorpusBuilderApp/shared_tools/project_config.py
+++ b/CorpusBuilderApp/shared_tools/project_config.py
@@ -243,6 +243,25 @@ class ProjectConfig:
         """Save configuration to YAML file"""
         with open(self.config_path, 'w') as f:
             yaml.dump(self.config, f, default_flow_style=False)
+
+    # Directory helper methods
+    def get_corpus_root(self) -> Path:
+        return Path(self.get('directories.corpus_root')).expanduser()
+
+    def get_corpus_dir(self) -> Path:
+        return self.get_corpus_root()
+
+    def get_raw_dir(self) -> Path:
+        return Path(self.get('directories.raw_data_dir')).expanduser()
+
+    def get_processed_dir(self) -> Path:
+        return Path(self.get('directories.processed_dir')).expanduser()
+
+    def get_metadata_dir(self) -> Path:
+        return Path(self.get('directories.metadata_dir')).expanduser()
+
+    def get_logs_dir(self) -> Path:
+        return Path(self.get('directories.logs_dir')).expanduser()
     
     @classmethod
     def from_yaml(cls, yaml_path: str, environment: Optional[str] = None) -> 'ProjectConfig':

--- a/CorpusBuilderApp/tests/unit/test_project_config_public.py
+++ b/CorpusBuilderApp/tests/unit/test_project_config_public.py
@@ -1,0 +1,49 @@
+import os
+import yaml
+from shared_tools.project_config import ProjectConfig
+
+
+def _write_yaml(path, corpus_dir):
+    data = {
+        'environment': 'test',
+        'environments': {
+            'test': {'corpus_dir': str(corpus_dir)}
+        }
+    }
+    with open(path, 'w') as f:
+        yaml.safe_dump(data, f)
+
+
+def test_from_yaml_and_getters(tmp_path, monkeypatch):
+    corpus_root = tmp_path / 'corpus'
+    _write_yaml(tmp_path / 'cfg.yaml', corpus_root)
+    monkeypatch.setenv('CORPUS_ROOT', str(corpus_root))
+    monkeypatch.setenv('RAW_DATA_DIR', str(corpus_root / 'raw'))
+    monkeypatch.setenv('PROCESSED_DIR', str(corpus_root / 'processed'))
+    monkeypatch.setenv('METADATA_DIR', str(corpus_root / 'metadata'))
+    monkeypatch.setenv('LOGS_DIR', str(corpus_root / 'logs'))
+    cfg = ProjectConfig.from_yaml(str(tmp_path / 'cfg.yaml'))
+    assert cfg.get_corpus_root() == corpus_root
+    assert cfg.get_corpus_dir() == corpus_root
+    assert cfg.get_raw_dir() == corpus_root / 'raw'
+    assert cfg.get_processed_dir() == corpus_root / 'processed'
+    assert cfg.get_metadata_dir() == corpus_root / 'metadata'
+    assert cfg.get_logs_dir() == corpus_root / 'logs'
+
+
+def test_get_set_and_save(tmp_path, monkeypatch):
+    corpus_root = tmp_path / 'corpus'
+    cfg_path = tmp_path / 'cfg.yaml'
+    _write_yaml(cfg_path, corpus_root)
+    monkeypatch.setenv('CORPUS_ROOT', str(corpus_root))
+    monkeypatch.setenv('RAW_DATA_DIR', str(corpus_root / 'raw'))
+    monkeypatch.setenv('PROCESSED_DIR', str(corpus_root / 'processed'))
+    monkeypatch.setenv('METADATA_DIR', str(corpus_root / 'metadata'))
+    monkeypatch.setenv('LOGS_DIR', str(corpus_root / 'logs'))
+    cfg = ProjectConfig.from_yaml(str(cfg_path))
+    cfg.set('api_keys.github_token', 'abc123')
+    cfg.save()
+    monkeypatch.setenv('GITHUB_TOKEN', 'abc123')
+    reloaded = ProjectConfig.from_yaml(str(cfg_path))
+    assert reloaded.get('api_keys.github_token') == 'abc123'
+


### PR DESCRIPTION
## Summary
- add helper methods for common directories in `ProjectConfig`
- test ProjectConfig save/load and directory helpers with temp YAML

## Testing
- `PYTHONPATH=..:. pytest -q tests/unit/test_project_config_public.py`


------
https://chatgpt.com/codex/tasks/task_e_684353758c348326b787eb575813c7fb