### PR TITLE
Add config-driven execution CLI

### DIFF
--- a/cli/execute_from_config.py
+++ b/cli/execute_from_config.py
@@ -1,0 +1,106 @@
+import argparse
+import logging
+from typing import List
+
+from shared_tools.project_config import ProjectConfig
+from shared_tools.ui_wrappers.wrapper_factory import (
+    create_collector_wrapper,
+    create_processor_wrapper,
+)
+from shared_tools.ui_wrappers.processors.corpus_balancer_wrapper import CorpusBalancerWrapper
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Execute pipeline components configured in a ProjectConfig YAML"
+    )
+    parser.add_argument("--config", required=True, help="Path to ProjectConfig YAML")
+    parser.add_argument("--run-all", action="store_true", help="Run collectors, processors and balancer")
+    parser.add_argument("--collect", action="store_true", help="Run enabled collectors")
+    parser.add_argument("--extract", action="store_true", help="Run enabled processors")
+    parser.add_argument("--balance", action="store_true", help="Run corpus balancer")
+    return parser.parse_args(argv)
+
+
+def load_config(path: str) -> ProjectConfig:
+    return ProjectConfig.from_yaml(path)
+
+
+def enabled_modules(config: ProjectConfig, section: str) -> List[str]:
+    modules = config.get(section, {}) or {}
+    return [name for name, cfg in modules.items() if isinstance(cfg, dict) and cfg.get("enabled", False)]
+
+
+def run_collectors(config: ProjectConfig, names: List[str]):
+    if not names:
+        raise RuntimeError("No enabled collectors found in configuration")
+    for name in names:
+        logger.info("Running collector: %s", name)
+        wrapper = create_collector_wrapper(name, config)
+        wrapper.start()
+        if getattr(wrapper, "worker", None):
+            wrapper.worker.wait()
+        logger.info("Collector %s finished", name)
+
+
+def run_processors(config: ProjectConfig, names: List[str]):
+    if not names:
+        raise RuntimeError("No enabled processors found in configuration")
+    for name in names:
+        wrapper_name = "text" if name in {"nonpdf", "text"} else name
+        logger.info("Running processor: %s", wrapper_name)
+        wrapper = create_processor_wrapper(wrapper_name, config)
+        wrapper.start()
+        if getattr(wrapper, "worker", None):
+            wrapper.worker.wait()
+        logger.info("Processor %s finished", wrapper_name)
+
+
+def run_balancer(config: ProjectConfig):
+    enabled = config.get("processors.corpus_balancer.enabled", False) or config.get(
+        "corpus_balancer.enabled", False
+    )
+    if not enabled:
+        raise RuntimeError("Corpus balancer not enabled in configuration")
+    logger.info("Running corpus balancer")
+    balancer = CorpusBalancerWrapper(config)
+    balancer.start_balancing()
+    if getattr(balancer, "worker", None):
+        balancer.worker.wait()
+    logger.info("Corpus balancer completed")
+
+
+def main(argv: List[str] | None = None):
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    config = load_config(args.config)
+
+    run_collect = args.run_all or args.collect
+    run_extract = args.run_all or args.extract
+    run_balance = args.run_all or args.balance
+
+    if not any([run_collect, run_extract, run_balance]):
+        raise RuntimeError("No phases selected to run")
+
+    if run_collect:
+        collectors = enabled_modules(config, "collectors")
+        run_collectors(config, collectors)
+
+    if run_extract:
+        processors = enabled_modules(config, "extractors") or enabled_modules(config, "processors")
+        # remove corpus_balancer if present
+        processors = [p for p in processors if p != "corpus_balancer"]
+        run_processors(config, processors)
+
+    if run_balance:
+        run_balancer(config)
+
+
+if __name__ == "__main__":
+    main()
+
+# Example usage:
+# python cli/execute_from_config.py --config examples/project_config.yaml --run-all

--- a/tests/cli/test_execute_from_config.py
+++ b/tests/cli/test_execute_from_config.py
@@ -1,0 +1,81 @@
+import sys
+from pathlib import Path as _Path, Path
+import types
+from typing import List
+import yaml
+
+# Add project root and package paths
+root = _Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(root))
+sys.path.insert(1, str(root / "CorpusBuilderApp"))
+
+# Stub heavy dependencies required by imported modules
+qtcore = types.SimpleNamespace(QObject=object, Signal=lambda *a, **k: lambda *a, **k: None, QThread=object, QTimer=object)
+plotly_subplots = types.ModuleType("plotly.subplots")
+plotly_subplots.make_subplots = lambda *a, **k: None
+sys.modules["plotly.subplots"] = plotly_subplots
+for mod in ["pandas", "numpy", "matplotlib", "matplotlib.pyplot", "seaborn", "plotly", "plotly.graph_objects", "plotly.express"]:
+    sys.modules.setdefault(mod, types.ModuleType(mod))
+pd = types.ModuleType("pandas"); pd.DataFrame = object; pd.read_csv = lambda *a, **k: None; sys.modules["pandas"] = pd
+np = types.ModuleType("numpy"); np.ndarray = object; np.array = lambda *a, **k: None; sys.modules["numpy"] = np
+scipy_stats = types.ModuleType("scipy.stats"); scipy_stats.entropy = lambda *a, **k: None; scipy_stats.chi2_contingency = lambda *a, **k: (None, None, None, None)
+scipy = types.ModuleType("scipy"); scipy.stats = scipy_stats
+sys.modules["scipy"] = scipy
+sys.modules["scipy.stats"] = scipy_stats
+sys.modules.setdefault("PySide6", types.SimpleNamespace(QtCore=qtcore))
+sys.modules.setdefault("PySide6.QtCore", qtcore)
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+
+import pytest
+import cli.execute_from_config as efc
+
+
+class DummyWrapper:
+    def __init__(self, name: str, log: List[str]):
+        self.name = name
+        self.log = log
+        self.worker = types.SimpleNamespace(wait=lambda: None)
+
+    def start(self):
+        self.log.append(self.name)
+
+
+class DummyBalancer:
+    def __init__(self, log: List[str]):
+        self.log = log
+        self.worker = types.SimpleNamespace(wait=lambda: None)
+
+    def start_balancing(self):
+        self.log.append("balancer")
+
+
+@pytest.fixture()
+def sample_config(tmp_path: Path) -> Path:
+    data = {
+        "collectors": {"foo": {"enabled": True}},
+        "extractors": {"pdf": {"enabled": True}},
+        "processors": {"corpus_balancer": {"enabled": True}},
+    }
+    path = tmp_path / "config.yaml"
+    with open(path, "w") as f:
+        yaml.safe_dump(data, f)
+    return path
+
+
+def test_run_all_sequence(monkeypatch, sample_config):
+    log: List[str] = []
+    monkeypatch.setattr(efc, "create_collector_wrapper", lambda name, cfg: DummyWrapper(f"collector-{name}", log))
+    monkeypatch.setattr(efc, "create_processor_wrapper", lambda name, cfg: DummyWrapper(f"processor-{name}", log))
+    monkeypatch.setattr(efc, "CorpusBalancerWrapper", lambda cfg: DummyBalancer(log))
+
+    efc.main(["--config", str(sample_config), "--run-all"])
+
+    assert log == ["collector-foo", "processor-pdf", "balancer"]
+
+
+def test_error_when_no_collectors(monkeypatch, tmp_path):
+    config_path = tmp_path / "c.yaml"
+    yaml.safe_dump({"collectors": {}}, open(config_path, "w"))
+
+    with pytest.raises(RuntimeError):
+        efc.main(["--config", str(config_path), "--collect"])


### PR DESCRIPTION
## Summary
- add `cli/execute_from_config.py` for batch running collectors and processors from a YAML config
- provide integration tests using dummy wrappers

## Testing
- `pytest tests/cli/test_execute_from_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684356ab17208326b2c5f6cc61ea14b2