### PR TITLE
Refactor deduplicator logging

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/processors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/processors_tab.py
@@ -431,11 +431,11 @@ class ProcessorsTab(QWidget):
             print(f"DEBUG: Using config_path: {config_path}")
             
             # Wrappers that expect config_path (string)
+
             path_wrappers = [
                 ('pdf', PDFExtractorWrapper),
                 ('text', TextExtractorWrapper),
                 ('balancer', CorpusBalancerWrapper),
-                ('deduplicator', DeduplicatorWrapper),
                 ('domain', DomainClassifierWrapper),
                 ('formula', FormulaExtractorWrapper),
                 ('chart', ChartImageExtractorWrapper)
@@ -446,7 +446,8 @@ class ProcessorsTab(QWidget):
                 ('quality', QualityControlWrapper),
                 ('language', LanguageConfidenceDetectorWrapper),
                 ('mt_detector', MachineTranslationDetectorWrapper),
-                ('financial', FinancialSymbolProcessorWrapper)
+                ('financial', FinancialSymbolProcessorWrapper),
+                ('deduplicator', DeduplicatorWrapper)
             ]
             
             # Initialize path-based wrappers


### PR DESCRIPTION
## Summary
- refactor deduplicator to use ProjectConfig and proper logging
- track previously processed files in `dedup_log.jsonl`
- integrate logger-based messages throughout
- initialize DeduplicatorWrapper via object wrapper in UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fitz)*

------
https://chatgpt.com/codex/tasks/task_e_6844097d9e8c8326946c52457cfbf7fa