### PR TITLE
Add stat card styling

### DIFF
--- a/CorpusBuilderApp/app/resources/styles/theme_light.qss
+++ b/CorpusBuilderApp/app/resources/styles/theme_light.qss
@@ -347,3 +347,21 @@ QFrame[objectName="card"] QChartView {
     color: transparent; /* Hide the title since we have separate header */
 }
 
+QFrame[objectName="stat-card"] {
+    background-color: #ffffff;
+    border: 1px solid #dcdcdc;
+    border-radius: 12px;
+    padding: 16px;
+}
+
+QLabel[objectName="card__header"] {
+    font-weight: 600;
+    font-size: 14px;
+    margin-bottom: 8px;
+    color: #111827;
+}
+
+QLabel[objectName="status-dot-success"] { background-color: #10b981; }
+QLabel[objectName="status-dot-error"]   { background-color: #ef4444; }
+QLabel[objectName="status-dot-warning"] { background-color: #f59e0b; }
+QLabel[objectName="status-dot-info"]    { background-color: #3b82f6; }


### PR DESCRIPTION
## Summary
- style stat cards and status dots in `theme_light.qss`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68440d2eccc4832694c111da19002487