### PR TITLE
Fix corpus manager signal hookup

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
@@ -374,9 +374,13 @@ class CorpusManagerTab(QWidget):
         batch_ops_layout.addLayout(progress_layout)
 
         # Connect corpus manager signals
-        self.manager.progress_updated.connect(lambda p, _op: self.batch_progress.setValue(p))
-        self.manager.status_updated.connect(self._handle_batch_status)
-        self.manager.operation_completed.connect(self._handle_operation_completed)
+        self.corpus_manager.progress_updated.connect(
+            lambda p, _op: self.batch_progress.setValue(p)
+        )
+        self.corpus_manager.status_updated.connect(self._handle_batch_status)
+        self.corpus_manager.operation_completed.connect(
+            self._handle_operation_completed
+        )
 
         main_layout.addWidget(batch_ops_group)
 


### PR DESCRIPTION
## Summary
- hook up progress/status/completed signals using `self.corpus_manager`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68440d1b48cc8326ade9eec36b371e1b