### PR TITLE
Fix balancer wrapper initialization

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/processors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/processors_tab.py
@@ -464,7 +464,7 @@ class ProcessorsTab(QWidget):
             for name, wrapper_class in object_wrappers:
                 try:
                     print(f"DEBUG: Initializing {wrapper_class.__name__} with config_object...")
-                    self.processor_wrappers[name] = wrapper_class(config_object)
+                    self.processor_wrappers[name] = wrapper_class(self.project_config)
                     print(f"DEBUG: {wrapper_class.__name__} initialized successfully")
                 except Exception as e:
                     print(f"ERROR: Failed to initialize {wrapper_class.__name__}: {e}")


### PR DESCRIPTION
## Summary
- ensure `CorpusBalancerWrapper` is initialized with the project config instance

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68441a131e5483268c72c3b12a05dba5