### PR TITLE
Update CLI balancer to use new rebalance

### DIFF
--- a/tests/cli/test_execute_from_config.py
+++ b/tests/cli/test_execute_from_config.py
@@ -45,8 +45,9 @@ class DummyBalancer:
         self.log = log
         self.worker = types.SimpleNamespace(wait=lambda: None)
 
-    def start_balancing(self):
+    def rebalance(self):
         self.log.append("balancer")
+        return {}
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- call `rebalance()` instead of `start_balancing()` in CLI
- store corpus balance results under the configured logs directory
- update CLI unit tests for the new behaviour

## Testing
- `pytest tests/cli/test_execute_from_config.py -q`
- `pytest tests/unit/test_deduplicator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68441a1524d4832691a05a1a568b4b7e