### PR TITLE
Refactor imports to new shared_tools path

### DIFF
--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/cli/collectors/collect_general_web_corpus.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/cli/collectors/collect_general_web_corpus.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 def run_general_web_corpus_collector(args, source_config, base_dir):
     print("[DEBUG] Entered general_web_corpus collector block")
     from CryptoFinanceCorpusBuilder.sources.specific_collectors.enhanced_client import CookieAuthClient
-    from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+    from shared_tools.config.domain_config import DOMAINS
     print("\nStarting General Web Corpus Collector...")
     # Set up test-safe output directory
     output_dir = Path(args.output_dir) if hasattr(args, 'output_dir') else Path("data/test_collect/general_web_corpus")

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/cli/consolidated_corpus(notused).py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/cli/consolidated_corpus(notused).py
@@ -4,7 +4,7 @@ import shutil
 import re
 from pathlib import Path
 from processors.domain_classifier import DomainClassifier
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+from shared_tools.config.domain_config import DOMAINS
 
 # Set up paths
 corpus_dir = Path("/workspace/data/corpus_1")

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/cli/crypto_corpus_cli.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/cli/crypto_corpus_cli.py
@@ -6,7 +6,7 @@ import sys
 import importlib
 import concurrent.futures
 import time
-from CryptoFinanceCorpusBuilder.shared_tools.storage.corpus_manager import CorpusManager
+from shared_tools.storage.corpus_manager import CorpusManager
 import os
 import requests
 import zipfile
@@ -266,7 +266,7 @@ def handle_auto_rebalance(args):
     """
     import logging
     from shared_tools.processors.corpus_balancer import CorpusAnalyzer
-    from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+    from shared_tools.config.domain_config import DOMAINS
     import json
     import sys
     import math

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/processors/base_extractor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/processors/base_extractor.py
@@ -6,7 +6,7 @@ import json
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
-from CryptoFinanceCorpusBuilder.models.quality_config import QualityConfig
+from shared_tools.models.quality_config import QualityConfig
 from CryptoFinanceCorpusBuilder.utils.extractor_utils import (
     safe_filename,
     count_tokens,

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/processors/domain_classifier.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/processors/domain_classifier.py
@@ -27,7 +27,7 @@ class DomainClassifier:
         elif config_path:
             self._load_config(config_path)
         else:
-            from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+            from shared_tools.config.domain_config import DOMAINS
             self.domain_config = DOMAINS
         
         # Extract keywords for each domain

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/cli/consolidate_corpus.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/cli/consolidate_corpus.py
@@ -9,9 +9,9 @@ import importlib.util
 from datetime import date
 import logging
 import argparse
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
-from CryptoFinanceCorpusBuilder.shared_tools.processors.domain_classifier import DomainClassifier
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.config.domain_config import DOMAINS
+from shared_tools.processors.domain_classifier import DomainClassifier
+from shared_tools.project_config import ProjectConfig
 
 def setup_logging(config: ProjectConfig = None) -> None:
     """Set up logging configuration."""

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/cli/consolidated_corpus(notused).py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/cli/consolidated_corpus(notused).py
@@ -3,8 +3,8 @@ import json
 import shutil
 import re
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.processors.domain_classifier import DomainClassifier
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+from shared_tools.processors.domain_classifier import DomainClassifier
+from shared_tools.config.domain_config import DOMAINS
 
 # Set up paths
 corpus_dir = Path("/workspace/data/corpus_1")

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/cli/crypto_corpus_cli.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/cli/crypto_corpus_cli.py
@@ -6,8 +6,8 @@ import sys
 import importlib
 import concurrent.futures
 import time
-from CryptoFinanceCorpusBuilder.shared_tools.storage.corpus_manager import CorpusManager
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.storage.corpus_manager import CorpusManager
+from shared_tools.project_config import ProjectConfig
 import os
 import requests
 import zipfile
@@ -20,10 +20,10 @@ import json as _json
 from dotenv import load_dotenv
 import traceback
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.collect_isda import run_isda_collector
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.collect_bitmex import run_bitmex_collector
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.collect_annas_main_library import run_annas_main_library_collector
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.collect_general_web_corpus import run_general_web_corpus_collector
+from shared_tools.collectors.collect_isda import run_isda_collector
+from shared_tools.collectors.collect_bitmex import run_bitmex_collector
+from shared_tools.collectors.collect_annas_main_library import run_annas_main_library_collector
+from shared_tools.collectors.collect_general_web_corpus import run_general_web_corpus_collector
 
 # Set up basic logging
 logging.basicConfig(

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/api_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/api_collector.py
@@ -1,5 +1,5 @@
 # sources/api_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 import json
 import requests
 import time

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/arxiv_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/arxiv_collector.py
@@ -6,7 +6,7 @@ import os
 import re
 from pathlib import Path
 from typing import List, Dict, Optional, Union
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.api_collector import ApiCollector
+from shared_tools.collectors.api_collector import ApiCollector
 import logging
 import argparse
 import requests

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/collect_annas_main_library.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/collect_annas_main_library.py
@@ -9,7 +9,7 @@ import logging
 import json
 import datetime
 from .base_collector import BaseCollector
-from CryptoFinanceCorpusBuilder.shared_tools.utils.domain_utils import get_domain_for_file
+from shared_tools.utils.domain_utils import get_domain_for_file
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -38,7 +38,7 @@ except ImportError:
 
 # Import ProjectConfig if available
 try:
-    from CryptoFinanceCorpusBuilder.config.project_config import ProjectConfig  # type: ignore
+    from shared_tools.config.project_config import ProjectConfig  # type: ignore
     logger.info("Successfully imported ProjectConfig")
 except ImportError:
     logger.warning("ProjectConfig not found. Legacy mode will be used if --project-config is not provided.")
@@ -62,7 +62,7 @@ def safe_filename(s):
 class AnnasMainLibraryCollector(BaseCollector):
     def __init__(self, config, account_cookie=None):
         if isinstance(config, str):
-            from CryptoFinanceCorpusBuilder.config.project_config import ProjectConfig
+            from shared_tools.config.project_config import ProjectConfig
             config = ProjectConfig(config, environment='test')
         super().__init__(config)
         self.account_cookie = account_cookie

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/collect_bitmex.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/collect_bitmex.py
@@ -8,7 +8,7 @@ import shutil
 import logging
 from pathlib import Path
 from .base_collector import BaseCollector
-from CryptoFinanceCorpusBuilder.shared_tools.utils.domain_utils import get_domain_for_file
+from shared_tools.utils.domain_utils import get_domain_for_file
 from typing import Union
 
 class UpdatedBitMEXCollector(BaseCollector):

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/collect_general_web_corpus.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/collect_general_web_corpus.py
@@ -5,9 +5,9 @@ import logging
 import datetime
 from pathlib import Path
 from dotenv import load_dotenv
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.enhanced_client import CookieAuthClient
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.config.domain_config import DOMAINS
+from shared_tools.collectors.enhanced_client import CookieAuthClient
+from shared_tools.collectors.base_collector import BaseCollector
 import importlib.util
 
 class GeneralWebCorpusCollector(BaseCollector):
@@ -132,6 +132,6 @@ if __name__ == "__main__":
         spec.loader.exec_module(domain_config)
         DOMAINS = domain_config.DOMAINS
     else:
-        from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+        from shared_tools.config.domain_config import DOMAINS
 
     run_general_web_corpus_collector(args, None, args.output_dir) 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/fred_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/fred_collector.py
@@ -5,7 +5,7 @@ import time
 import pandas as pd
 from pathlib import Path
 from typing import List, Dict, Optional, Union, Any
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 from dotenv import load_dotenv
 import requests
 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/github_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/github_collector.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from urllib.parse import quote
 from typing import List, Optional, Union, Dict, Any
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.api_collector import ApiCollector
+from shared_tools.collectors.api_collector import ApiCollector
 import re
 
 def ascii_safe(s):

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/new_source_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/new_source_collector.py
@@ -1,5 +1,5 @@
 # sources/specific_collectors/new_source_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.web_collector import WebCollector
+from shared_tools.collectors.web_collector import WebCollector
 
 class NewSourceCollector(WebCollector):
     def __init__(self, output_dir, delay_range=(3, 7)):

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/quantopian_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/quantopian_collector.py
@@ -1,5 +1,5 @@
 # sources/specific_collectors/quantopian_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 import os
 import re
 import json

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/repo_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/repo_collector.py
@@ -1,5 +1,5 @@
 # sources/repo_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 import subprocess
 import os
 import shutil

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/web_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/web_collector.py
@@ -1,5 +1,5 @@
 # sources/web_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urlparse

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/Prev_working_processors/base_extractor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/Prev_working_processors/base_extractor.py
@@ -6,7 +6,7 @@ import json
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
-from CryptoFinanceCorpusBuilder.models.quality_config import QualityConfig
+from shared_tools.models.quality_config import QualityConfig
 from CryptoFinanceCorpusBuilder.utils.extractor_utils import (
     safe_filename,
     count_tokens,

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/Prev_working_processors/domain_classifier.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/Prev_working_processors/domain_classifier.py
@@ -27,7 +27,7 @@ class DomainClassifier:
         elif config_path:
             self._load_config(config_path)
         else:
-            from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+            from shared_tools.config.domain_config import DOMAINS
             self.domain_config = DOMAINS
         
         # Extract keywords for each domain

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_cli/consolidated_corpus(notused).py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_cli/consolidated_corpus(notused).py
@@ -4,7 +4,7 @@ import shutil
 import re
 from pathlib import Path
 from processors.domain_classifier import DomainClassifier
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+from shared_tools.config.domain_config import DOMAINS
 
 # Set up paths
 corpus_dir = Path("/workspace/data/corpus_1")

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_cli/crypto_corpus_cli.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_cli/crypto_corpus_cli.py
@@ -6,7 +6,7 @@ import sys
 import importlib
 import concurrent.futures
 import time
-from CryptoFinanceCorpusBuilder.shared_tools.storage.corpus_manager import CorpusManager
+from shared_tools.storage.corpus_manager import CorpusManager
 import os
 import requests
 import zipfile
@@ -266,7 +266,7 @@ def handle_auto_rebalance(args):
     """
     import logging
     from shared_tools.processors.corpus_balancer import CorpusAnalyzer
-    from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+    from shared_tools.config.domain_config import DOMAINS
     import json
     import sys
     import math

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_storage/corpus_manager.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_storage/corpus_manager.py
@@ -6,7 +6,7 @@ import logging
 import datetime
 from pathlib import Path
 import uuid
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+from shared_tools.config.domain_config import DOMAINS
 
 class CorpusManager:
     """Manage the crypto-finance corpus structure"""
@@ -18,7 +18,7 @@ class CorpusManager:
         # Load domain configuration if not provided
         if domain_config is None:
             try:
-                from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+                from shared_tools.config.domain_config import DOMAINS
                 self.domain_config = DOMAINS
             except ImportError:
                 self.domain_config = {}

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_utils/config_sync.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_utils/config_sync.py
@@ -11,7 +11,7 @@ import pprint
 import argparse
 import datetime
 
-from CryptoFinanceCorpusBuilder.config import balancer_config, domain_config
+from shared_tools.config import balancer_config, domain_config
 
 REFERENCE_DOMAINS = balancer_config.DOMAIN_BALANCE_CONFIG
 EXTRACTOR_DOMAINS = domain_config.DOMAINS

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_utils/config_validator.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_utils/config_validator.py
@@ -11,7 +11,7 @@ from typing import Dict, Any
 
 # Import configs
 sys.path.insert(0, str(Path(__file__).parent.parent / 'config'))
-from CryptoFinanceCorpusBuilder.config import balancer_config, domain_config
+from shared_tools.config import balancer_config, domain_config
 
 REFERENCE_DOMAINS = balancer_config.DOMAIN_BALANCE_CONFIG
 EXTRACTOR_DOMAINS = domain_config.DOMAINS

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_utils/domain_utils.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_utils/domain_utils.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Optional, Union, Any
 
 # Try to load domains from config, else fallback
 try:
-    from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS as _CONFIG_DOMAINS
+    from shared_tools.config.domain_config import DOMAINS as _CONFIG_DOMAINS
 except ImportError:
     _CONFIG_DOMAINS: Optional[Dict[str, Dict[str, Any]]] = None
 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/api_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/api_collector.py
@@ -1,5 +1,5 @@
 # sources/api_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 import json
 import requests
 import time

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/arxiv_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/arxiv_collector.py
@@ -5,7 +5,7 @@ import time
 import os
 import re
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.api_collector import ApiCollector
+from shared_tools.collectors.api_collector import ApiCollector
 import logging
 import argparse
 import requests

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/collect_annas_main_library.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/collect_annas_main_library.py
@@ -36,7 +36,7 @@ except ImportError:
 
 # Import ProjectConfig if available
 try:
-    from CryptoFinanceCorpusBuilder.config.project_config import ProjectConfig  # type: ignore
+    from shared_tools.config.project_config import ProjectConfig  # type: ignore
     logger.info("Successfully imported ProjectConfig")
 except ImportError:
     logger.warning("ProjectConfig not found. Legacy mode will be used if --project-config is not provided.")

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/collect_general_web_corpus.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/collect_general_web_corpus.py
@@ -5,8 +5,8 @@ import logging
 import datetime
 from pathlib import Path
 from dotenv import load_dotenv
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.enhanced_client import CookieAuthClient
+from shared_tools.config.domain_config import DOMAINS
+from shared_tools.collectors.enhanced_client import CookieAuthClient
 import importlib.util
 
 def run_general_web_corpus_collector(args, source_config, base_dir):
@@ -79,6 +79,6 @@ if __name__ == "__main__":
         spec.loader.exec_module(domain_config)
         DOMAINS = domain_config.DOMAINS
     else:
-        from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+        from shared_tools.config.domain_config import DOMAINS
 
     run_general_web_corpus_collector(args, None, args.output_dir) 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/fred_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/fred_collector.py
@@ -4,7 +4,7 @@ import json
 import time
 import pandas as pd
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.api_collector import ApiCollector
+from shared_tools.collectors.api_collector import ApiCollector
 from dotenv import load_dotenv
 
 class FREDCollector(ApiCollector):

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/github_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/github_collector.py
@@ -4,7 +4,7 @@ import json
 import time
 from pathlib import Path
 from urllib.parse import quote
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.api_collector import ApiCollector
+from shared_tools.collectors.api_collector import ApiCollector
 import re
 
 def ascii_safe(s):

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/new_source_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/new_source_collector.py
@@ -1,5 +1,5 @@
 # sources/specific_collectors/new_source_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.web_collector import WebCollector
+from shared_tools.collectors.web_collector import WebCollector
 
 class NewSourceCollector(WebCollector):
     def __init__(self, output_dir, delay_range=(3, 7)):

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/quantopian_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/quantopian_collector.py
@@ -1,5 +1,5 @@
 # sources/specific_collectors/quantopian_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.repo_collector import RepoCollector
+from shared_tools.collectors.repo_collector import RepoCollector
 import os
 import re
 import json

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/repo_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/repo_collector.py
@@ -1,5 +1,5 @@
 # sources/repo_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 import subprocess
 import os
 import shutil

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/web_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/web_collector.py
@@ -1,5 +1,5 @@
 # sources/web_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urlparse

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/chart_image_extractor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/chart_image_extractor.py
@@ -682,7 +682,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from CryptoFinanceCorpusBuilder.shared_tools.config.project_config import ProjectConfig
+        from shared_tools.config.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/domainsmanager.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/domainsmanager.py
@@ -3,7 +3,7 @@ import os
 import json
 from pathlib import Path
 import logging
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+from shared_tools.config.domain_config import DOMAINS
 
 class DomainManager:
     """Manager for crypto-finance corpus domains"""

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/finacial_symbol_processor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/finacial_symbol_processor.py
@@ -791,7 +791,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from CryptoFinanceCorpusBuilder.shared_tools.config.project_config import ProjectConfig
+        from shared_tools.config.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/formula_extractor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/formula_extractor.py
@@ -477,7 +477,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from CryptoFinanceCorpusBuilder.shared_tools.config.project_config import ProjectConfig
+        from shared_tools.config.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/storage/corpus_manager.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/storage/corpus_manager.py
@@ -9,7 +9,7 @@ import uuid
 import numpy as np
 from collections import Counter
 from math import log2
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+from shared_tools.config.domain_config import DOMAINS
 
 class CorpusManager:
     """Manage the crypto-finance corpus structure"""

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/config_sync.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/config_sync.py
@@ -11,7 +11,7 @@ import pprint
 import argparse
 import datetime
 
-from CryptoFinanceCorpusBuilder.config import balancer_config, domain_config
+from shared_tools.config import balancer_config, domain_config
 
 REFERENCE_DOMAINS = balancer_config.DOMAIN_BALANCE_CONFIG
 EXTRACTOR_DOMAINS = domain_config.DOMAINS

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/config_validator.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/config_validator.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 try:
-    from CryptoFinanceCorpusBuilder.config import balancer_config, domain_config
+    from shared_tools.config import balancer_config, domain_config
 except ImportError:
     # Fallback for direct script execution (not as a module)
     import sys

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/domain_utils.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/domain_utils.py
@@ -15,12 +15,12 @@ from typing import Dict, List, Optional, Union, Any
 
 # Try to load domains from config, else fallback
 try:
-    from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS as _CONFIG_DOMAINS
+    from shared_tools.config.domain_config import DOMAINS as _CONFIG_DOMAINS
 except ImportError:
     _CONFIG_DOMAINS: Optional[Dict[str, Dict[str, Any]]] = None
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+    from shared_tools.project_config import ProjectConfig
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/extractor_utils.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/extractor_utils.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import os
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+    from shared_tools.project_config import ProjectConfig
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/generate_corpus_report.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/generate_corpus_report.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional, Union, Dict, List, Any
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+    from shared_tools.project_config import ProjectConfig
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/metadata_normalizer.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/metadata_normalizer.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Optional, Union
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+    from shared_tools.project_config import ProjectConfig
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/metadata_validator.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/metadata_validator.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Optional, Union, List, Dict
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+    from shared_tools.project_config import ProjectConfig
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/storage/corpus_manager.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/storage/corpus_manager.py
@@ -6,7 +6,7 @@ import logging
 import datetime
 from pathlib import Path
 import uuid
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.project_config import ProjectConfig
 
 class CorpusManager:
     """Manage the crypto-finance corpus structure"""

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_annas_library_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_annas_library_collector.py
@@ -4,8 +4,8 @@ import pytest
 import logging
 from pathlib import Path
 from dotenv import load_dotenv
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.collect_annas_main_library import AnnasMainLibraryCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.collect_annas_main_library import AnnasMainLibraryCollector
+from shared_tools.project_config import ProjectConfig
 
 # Set up logging
 logging.basicConfig(level=logging.DEBUG)

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_api_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_api_collector.py
@@ -4,8 +4,8 @@ import pytest
 import json
 from pathlib import Path
 from dotenv import load_dotenv
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.api_collector import ApiCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.api_collector import ApiCollector
+from shared_tools.project_config import ProjectConfig
 
 # Load environment variables
 load_dotenv()

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_arxiv_collector_projectconfig.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_arxiv_collector_projectconfig.py
@@ -2,8 +2,8 @@ import os
 import sys
 import pytest
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.arxiv_collector import ArxivCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.arxiv_collector import ArxivCollector
+from shared_tools.project_config import ProjectConfig
 
 @pytest.fixture
 def config():

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_bitmex_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_bitmex_collector.py
@@ -5,8 +5,8 @@ import json
 import shutil
 from pathlib import Path
 from dotenv import load_dotenv
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.collect_bitmex import UpdatedBitMEXCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.collect_bitmex import UpdatedBitMEXCollector
+from shared_tools.project_config import ProjectConfig
 
 # Load environment variables from .env file
 load_dotenv()

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_fred_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_fred_collector.py
@@ -3,8 +3,8 @@ import sys
 import pytest
 from pathlib import Path
 from dotenv import load_dotenv
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.fred_collector import FREDCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.fred_collector import FREDCollector
+from shared_tools.project_config import ProjectConfig
 
 # Load environment variables from .env file
 load_dotenv()

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_general_web_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_general_web_collector.py
@@ -2,8 +2,8 @@ import os
 import sys
 import pytest
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.general_web_collector import GeneralWebCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.general_web_collector import GeneralWebCollector
+from shared_tools.project_config import ProjectConfig
 
 @pytest.fixture
 def config():

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_github_collector_projectconfig.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_github_collector_projectconfig.py
@@ -2,8 +2,8 @@ import os
 import sys
 import pytest
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.github_collector import GitHubCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.github_collector import GitHubCollector
+from shared_tools.project_config import ProjectConfig
 
 @pytest.fixture
 def config():

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_isda_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_isda_collector.py
@@ -2,8 +2,8 @@ import pytest
 from pathlib import Path
 import json
 import os
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.collect_isda import ISDADocumentationCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.collect_isda import ISDADocumentationCollector
+from shared_tools.project_config import ProjectConfig
 
 @pytest.fixture
 def config():

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_pdf_extractor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_pdf_extractor.py
@@ -4,7 +4,7 @@ import tempfile
 import json
 import shutil
 from CryptoFinanceCorpusBuilder.processors.pdf_extractor import PDFExtractor
-from CryptoFinanceCorpusBuilder.models.quality_config import QualityConfig
+from shared_tools.models.quality_config import QualityConfig
 
 class TestPDFExtractor(unittest.TestCase):
     def setUp(self):

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_quantopian_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_quantopian_collector.py
@@ -2,8 +2,8 @@ import os
 import sys
 import pytest
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.quantopian_collector import QuantopianCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.quantopian_collector import QuantopianCollector
+from shared_tools.project_config import ProjectConfig
 
 @pytest.fixture
 def config():

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_repo_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_repo_collector.py
@@ -2,8 +2,8 @@ import os
 import sys
 import pytest
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.repo_collector import RepoCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.repo_collector import RepoCollector
+from shared_tools.project_config import ProjectConfig
 
 @pytest.fixture
 def config():

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_scidb_collector_projectconfig.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_scidb_collector_projectconfig.py
@@ -2,8 +2,8 @@ import os
 import sys
 import pytest
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.enhanced_scidb_collector import SciDBCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.enhanced_scidb_collector import SciDBCollector
+from shared_tools.project_config import ProjectConfig
 
 @pytest.fixture
 def config():

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_web_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_web_collector.py
@@ -2,8 +2,8 @@ import os
 import sys
 import pytest
 from pathlib import Path
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.web_collector import WebCollector
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.web_collector import WebCollector
+from shared_tools.project_config import ProjectConfig
 
 @pytest.fixture
 def config():

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/test_base_extractor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/test_base_extractor.py
@@ -4,7 +4,7 @@ import tempfile
 import json
 from typing import Dict, Any, Tuple
 from CryptoFinanceCorpusBuilder.processors.base_extractor import BaseExtractor, ExtractionError
-from CryptoFinanceCorpusBuilder.models.quality_config import QualityConfig
+from shared_tools.models.quality_config import QualityConfig
 
 class TestExtractor(BaseExtractor):
     """Test implementation of BaseExtractor."""

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/test_corpus_balance.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/test_corpus_balance.py
@@ -15,7 +15,7 @@ import numpy as np
 from CryptoFinanceCorpusBuilder.processors.corpus_balancer import (
     CorpusAnalyzer, CorpusRebalancer, CorpusVisualizer, CorpusBalancerCLI
 )
-from CryptoFinanceCorpusBuilder.config.balancer_config import BalancerConfig
+from shared_tools.config.balancer_config import BalancerConfig
 
 class TestCorpusAnalyzer(unittest.TestCase):
     """Test cases for CorpusAnalyzer class."""

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/test_quality_config.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/test_quality_config.py
@@ -1,7 +1,7 @@
 import unittest
 from pathlib import Path
 import json
-from CryptoFinanceCorpusBuilder.models.quality_config import (
+from shared_tools.models.quality_config import (
     QualityConfig,
     LanguageDetectionConfig,
     CorruptionDetectionConfig,

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/utils/config_sync.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/utils/config_sync.py
@@ -11,7 +11,7 @@ import pprint
 import argparse
 import datetime
 
-from CryptoFinanceCorpusBuilder.config import balancer_config, domain_config
+from shared_tools.config import balancer_config, domain_config
 
 REFERENCE_DOMAINS = balancer_config.DOMAIN_BALANCE_CONFIG
 EXTRACTOR_DOMAINS = domain_config.DOMAINS

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/utils/config_validator.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/utils/config_validator.py
@@ -11,7 +11,7 @@ from typing import Dict, Any
 
 # Import configs
 sys.path.insert(0, str(Path(__file__).parent.parent / 'config'))
-from CryptoFinanceCorpusBuilder.config import balancer_config, domain_config
+from shared_tools.config import balancer_config, domain_config
 
 REFERENCE_DOMAINS = balancer_config.DOMAIN_BALANCE_CONFIG
 EXTRACTOR_DOMAINS = domain_config.DOMAINS

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/utils/domain_utils.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/utils/domain_utils.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Optional, Union, Any
 
 # Try to load domains from config, else fallback
 try:
-    from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS as _CONFIG_DOMAINS
+    from shared_tools.config.domain_config import DOMAINS as _CONFIG_DOMAINS
 except ImportError:
     _CONFIG_DOMAINS: Optional[Dict[str, Dict[str, Any]]] = None
 

--- a/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
@@ -136,7 +136,7 @@ class DashboardTab(QWidget):
             pass
 
         try:
-            from CryptoFinanceCorpusBuilder.shared_tools.storage.corpus_manager import (
+            from shared_tools.storage.corpus_manager import (
                 CorpusManager,
             )
 

--- a/CorpusBuilderApp/shared_tools/collectors/collect_annas_main_library.py
+++ b/CorpusBuilderApp/shared_tools/collectors/collect_annas_main_library.py
@@ -9,7 +9,7 @@ import logging
 import json
 import datetime
 from .base_collector import BaseCollector
-from CryptoFinanceCorpusBuilder.shared_tools.utils.domain_utils import get_domain_for_file
+from shared_tools.utils.domain_utils import get_domain_for_file
 from shared_tools.utils.extractor_utils import safe_filename
 
 # Set up logging
@@ -42,7 +42,7 @@ except ImportError:
 
 # Import ProjectConfig if available
 try:
-    from CryptoFinanceCorpusBuilder.config.project_config import ProjectConfig  # type: ignore
+    from shared_tools.config.project_config import ProjectConfig  # type: ignore
     logger.info("Successfully imported ProjectConfig")
 except ImportError:
     logger.warning("ProjectConfig not found. Legacy mode will be used if --project-config is not provided.")
@@ -62,7 +62,7 @@ def load_existing_titles(existing_titles_path):
 class AnnasMainLibraryCollector(BaseCollector):
     def __init__(self, config, account_cookie=None):
         if isinstance(config, str):
-            from CryptoFinanceCorpusBuilder.config.project_config import ProjectConfig
+            from shared_tools.config.project_config import ProjectConfig
             config = ProjectConfig(config, environment='test')
         super().__init__(config)
         self.account_cookie = account_cookie

--- a/CorpusBuilderApp/shared_tools/collectors/collect_bitmex.py
+++ b/CorpusBuilderApp/shared_tools/collectors/collect_bitmex.py
@@ -8,7 +8,7 @@ import shutil
 import logging
 from pathlib import Path
 from .base_collector import BaseCollector
-from CryptoFinanceCorpusBuilder.shared_tools.utils.domain_utils import get_domain_for_file
+from shared_tools.utils.domain_utils import get_domain_for_file
 from typing import Union
 
 class UpdatedBitMEXCollector(BaseCollector):

--- a/CorpusBuilderApp/shared_tools/collectors/collect_general_web_corpus.py
+++ b/CorpusBuilderApp/shared_tools/collectors/collect_general_web_corpus.py
@@ -7,9 +7,9 @@ import logging
 import datetime
 from pathlib import Path
 from dotenv import load_dotenv
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.enhanced_client import CookieAuthClient
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.config.domain_config import DOMAINS
+from shared_tools.collectors.enhanced_client import CookieAuthClient
+from shared_tools.collectors.base_collector import BaseCollector
 import importlib.util
 
 class GeneralWebCorpusCollector(BaseCollector):
@@ -134,6 +134,6 @@ if __name__ == "__main__":
         spec.loader.exec_module(domain_config)
         DOMAINS = domain_config.DOMAINS
     else:
-        from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+        from shared_tools.config.domain_config import DOMAINS
 
     run_general_web_corpus_collector(args, None, args.output_dir) 

--- a/CorpusBuilderApp/shared_tools/collectors/fred_collector.py
+++ b/CorpusBuilderApp/shared_tools/collectors/fred_collector.py
@@ -7,7 +7,7 @@ import time
 import pandas as pd
 from pathlib import Path
 from typing import List, Dict, Optional, Union, Any
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 from dotenv import load_dotenv
 import requests
 

--- a/CorpusBuilderApp/shared_tools/collectors/new_source_collector.py
+++ b/CorpusBuilderApp/shared_tools/collectors/new_source_collector.py
@@ -1,5 +1,5 @@
 # sources/specific_collectors/new_source_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.web_collector import WebCollector
+from shared_tools.collectors.web_collector import WebCollector
 
 class NewSourceCollector(WebCollector):
     def __init__(self, output_dir, delay_range=(3, 7)):

--- a/CorpusBuilderApp/shared_tools/collectors/quantopian_collector.py
+++ b/CorpusBuilderApp/shared_tools/collectors/quantopian_collector.py
@@ -1,5 +1,5 @@
 # sources/specific_collectors/quantopian_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 import os
 import re
 import json

--- a/CorpusBuilderApp/shared_tools/collectors/repo_collector.py
+++ b/CorpusBuilderApp/shared_tools/collectors/repo_collector.py
@@ -1,5 +1,5 @@
 # sources/repo_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 import subprocess
 import os
 import shutil

--- a/CorpusBuilderApp/shared_tools/collectors/web_collector.py
+++ b/CorpusBuilderApp/shared_tools/collectors/web_collector.py
@@ -1,5 +1,5 @@
 # sources/web_collector.py
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.base_collector import BaseCollector
+from shared_tools.collectors.base_collector import BaseCollector
 import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urlparse

--- a/CorpusBuilderApp/shared_tools/processors/chart_image_extractor.py
+++ b/CorpusBuilderApp/shared_tools/processors/chart_image_extractor.py
@@ -682,7 +682,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from CryptoFinanceCorpusBuilder.shared_tools.config.project_config import ProjectConfig
+        from shared_tools.config.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/shared_tools/processors/domainsmanager.py
+++ b/CorpusBuilderApp/shared_tools/processors/domainsmanager.py
@@ -3,7 +3,7 @@ import os
 import json
 from pathlib import Path
 import logging
-from CryptoFinanceCorpusBuilder.config.domain_config import DOMAINS
+from shared_tools.config.domain_config import DOMAINS
 from typing import Dict, List, Optional, Any
 
 class DomainsManager:

--- a/CorpusBuilderApp/shared_tools/processors/finacial_symbol_processor.py
+++ b/CorpusBuilderApp/shared_tools/processors/finacial_symbol_processor.py
@@ -791,7 +791,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from CryptoFinanceCorpusBuilder.shared_tools.config.project_config import ProjectConfig
+        from shared_tools.config.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/shared_tools/processors/formula_extractor.py
+++ b/CorpusBuilderApp/shared_tools/processors/formula_extractor.py
@@ -477,7 +477,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from CryptoFinanceCorpusBuilder.shared_tools.config.project_config import ProjectConfig
+        from shared_tools.config.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/shared_tools/utils/config_sync.py
+++ b/CorpusBuilderApp/shared_tools/utils/config_sync.py
@@ -11,7 +11,7 @@ import pprint
 import argparse
 import datetime
 
-from CryptoFinanceCorpusBuilder.config import balancer_config, domain_config
+from shared_tools.config import balancer_config, domain_config
 
 REFERENCE_DOMAINS = balancer_config.DOMAIN_BALANCE_CONFIG
 EXTRACTOR_DOMAINS = domain_config.DOMAINS

--- a/CorpusBuilderApp/shared_tools/utils/config_validator.py
+++ b/CorpusBuilderApp/shared_tools/utils/config_validator.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 try:
-    from CryptoFinanceCorpusBuilder.config import balancer_config, domain_config
+    from shared_tools.config import balancer_config, domain_config
 except ImportError:
     # Fallback for direct script execution (not as a module)
     import sys

--- a/CorpusBuilderApp/shared_tools/utils/extractor_utils.py
+++ b/CorpusBuilderApp/shared_tools/utils/extractor_utils.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import os
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+    from shared_tools.project_config import ProjectConfig
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/shared_tools/utils/extractor_utils.pyi
+++ b/CorpusBuilderApp/shared_tools/utils/extractor_utils.pyi
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union, Any
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig  # type: ignore
+    from shared_tools.project_config import ProjectConfig  # type: ignore
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/shared_tools/utils/generate_corpus_report.py
+++ b/CorpusBuilderApp/shared_tools/utils/generate_corpus_report.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional, Union, Dict, List, Any
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+    from shared_tools.project_config import ProjectConfig
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/shared_tools/utils/metadata_normalizer.py
+++ b/CorpusBuilderApp/shared_tools/utils/metadata_normalizer.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Optional, Union
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+    from shared_tools.project_config import ProjectConfig
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/shared_tools/utils/metadata_validator.py
+++ b/CorpusBuilderApp/shared_tools/utils/metadata_validator.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Optional, Union, List, Dict
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+    from shared_tools.project_config import ProjectConfig
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/tests/integration/test_multi_collector_flow.py
+++ b/CorpusBuilderApp/tests/integration/test_multi_collector_flow.py
@@ -1,7 +1,7 @@
 import pytest
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.fred_collector import FREDCollector
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.github_collector import GitHubCollector
+from shared_tools.project_config import ProjectConfig
+from shared_tools.collectors.fred_collector import FREDCollector
+from shared_tools.collectors.github_collector import GitHubCollector
 
 @pytest.mark.skip("Audit stub – implement later")
 def test_run_fred_and_github_collectors(monkeypatch, tmp_path):

--- a/CorpusBuilderApp/tests/integration/test_project_config_edges.py
+++ b/CorpusBuilderApp/tests/integration/test_project_config_edges.py
@@ -1,5 +1,5 @@
 import pytest
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+from shared_tools.project_config import ProjectConfig
 
 @pytest.mark.skip("Audit stub – implement later")
 def test_load_minimal_config(tmp_path):

--- a/CorpusBuilderApp/tests/unit/test_cli_consolidate.py
+++ b/CorpusBuilderApp/tests/unit/test_cli_consolidate.py
@@ -1,5 +1,5 @@
 import pytest
-from CryptoFinanceCorpusBuilder.shared_tools.cli import consolidate_corpus
+from shared_tools.cli import consolidate_corpus
 
 @pytest.mark.skip("Audit stub – implement later")
 def test_cli_argument_parsing(monkeypatch):


### PR DESCRIPTION
## Summary
- update imports referencing `CryptoFinanceCorpusBuilder` to the new `shared_tools` package
- adjust tests and utilities accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68442083de40832696ef2decfa33f25d