### PR TITLE
fix: migrate formula/symbol/chart extractors to modern ProjectConfig

### DIFF
--- a/CorpusBuilderApp/shared_tools/processors/chart_image_extractor.py
+++ b/CorpusBuilderApp/shared_tools/processors/chart_image_extractor.py
@@ -682,7 +682,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from shared_tools.config.project_config import ProjectConfig
+        from shared_tools.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/shared_tools/processors/finacial_symbol_processor.py
+++ b/CorpusBuilderApp/shared_tools/processors/finacial_symbol_processor.py
@@ -791,7 +791,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from shared_tools.config.project_config import ProjectConfig
+        from shared_tools.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/shared_tools/processors/formula_extractor.py
+++ b/CorpusBuilderApp/shared_tools/processors/formula_extractor.py
@@ -477,7 +477,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from shared_tools.config.project_config import ProjectConfig
+        from shared_tools.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:


### PR DESCRIPTION
## Summary
- point formula, symbol, and chart processors to shared_tools.project_config.ProjectConfig

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_6844281a4f088326bafc61b2f04213c6