### PR TITLE
Fix safe_filename import

### DIFF
--- a/CorpusBuilderApp/shared_tools/collectors/enhanced_client.py
+++ b/CorpusBuilderApp/shared_tools/collectors/enhanced_client.py
@@ -13,7 +13,7 @@ import undetected_chromedriver as uc  # type: ignore
 from selenium.webdriver.chrome.options import Options
 from selenium.common.exceptions import NoSuchElementException
 import shutil
-from CryptoFinanceCorpusBuilder.utils.extractor_utils import safe_filename  # type: ignore
+from shared_tools.utils.extractor_utils import safe_filename  # type: ignore
 
 # Replace load_dotenv("/workspace/notebooks/.env") with project root .env
 load_dotenv(os.path.join(os.path.dirname(__file__), '../../.env'))


### PR DESCRIPTION
## Summary
- adjust module path for safe_filename in `enhanced_client`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz', and 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68442b32d3f48326910200c10a31c9ea