### PR TITLE
Update extractor utils import

### DIFF
--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/processors/base_extractor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/processors/base_extractor.py
@@ -7,7 +7,7 @@ import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 from shared_tools.models.quality_config import QualityConfig
-from CryptoFinanceCorpusBuilder.utils.extractor_utils import (
+from shared_tools.utils.extractor_utils import (
     safe_filename,
     count_tokens,
     extract_metadata,


### PR DESCRIPTION
## Summary
- redirect base_extractor to use extractor_utils from `shared_tools`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68442b395be88326921d27b77de99cf7