### PR TITLE
Fix domain config access in BaseCollector

### DIFF
--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/base_collector.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/base_collector.py
@@ -33,6 +33,13 @@ class BaseCollector:
         self.config = config
         self.raw_data_dir = Path(config.raw_data_dir)
         self.delay_range = delay_range
+
+        if hasattr(config, "domain_configs"):
+            self.domain_configs = config.domain_configs
+        else:
+            self.domain_configs = (
+                config.get_processor_config("domain").get("domain_configs", {})
+            )
         
         # Configure logging
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -63,7 +70,7 @@ class BaseCollector:
         self.logger.info("Setting up domain-based directory structure...")
         
         # Get domains from config
-        domains = list(self.config.domain_configs.keys())
+        domains = list(self.domain_configs.keys())
         if not domains:
             # Fallback to default domains if none configured
             domains = [
@@ -95,7 +102,7 @@ class BaseCollector:
     def _get_output_path(self, domain: str, content_type: str, filename: str) -> Path:
         """Get the correct output path based on domain and content type."""
         # Get valid domains from config
-        valid_domains = list(self.config.domain_configs.keys())
+        valid_domains = list(self.domain_configs.keys())
         
         if domain not in valid_domains:
             domain = 'other'

--- a/CorpusBuilderApp/shared_tools/collectors/base_collector.py
+++ b/CorpusBuilderApp/shared_tools/collectors/base_collector.py
@@ -33,6 +33,13 @@ class BaseCollector:
         self.config = config
         self.raw_data_dir = Path(config.raw_data_dir)
         self.delay_range = delay_range
+
+        if hasattr(config, "domain_configs"):
+            self.domain_configs = config.domain_configs
+        else:
+            self.domain_configs = (
+                config.get_processor_config("domain").get("domain_configs", {})
+            )
         
         # Configure logging
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -63,7 +70,7 @@ class BaseCollector:
         self.logger.info("Setting up domain-based directory structure...")
         
         # Get domains from config
-        domains = list(self.config.domain_configs.keys())
+        domains = list(self.domain_configs.keys())
         if not domains:
             # Fallback to default domains if none configured
             domains = [
@@ -95,7 +102,7 @@ class BaseCollector:
     def _get_output_path(self, domain: str, content_type: str, filename: str) -> Path:
         """Get the correct output path based on domain and content type."""
         # Get valid domains from config
-        valid_domains = list(self.config.domain_configs.keys())
+        valid_domains = list(self.domain_configs.keys())
         
         if domain not in valid_domains:
             domain = 'other'


### PR DESCRIPTION
## Summary
- determine domain configs from config objects that don't expose `.domain_configs`
- use `self.domain_configs` for directory setup and path helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68442b9ceca8832680fe53eccab72dce