### PR TITLE
Update corpus manager imports

### DIFF
--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/check_orphaned_txts_vs_pdfs.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/check_orphaned_txts_vs_pdfs.py
@@ -3,11 +3,7 @@ from pathlib import Path
 import sys
 import os
 
-try:
-    from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
-except ImportError:
-    sys.path.append(str(Path(__file__).resolve().parent.parent))
-    from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
+from shared_tools.storage.corpus_manager import CorpusManager
 
 def check_orphaned_txts_vs_pdfs(corpus_dir, metadata_path=None):
     corpus_dir = Path(corpus_dir)

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/clean_metadata.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/clean_metadata.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
+from shared_tools.storage.corpus_manager import CorpusManager
 
 def clean_stale_metadata(corpus_dir, metadata_path=None):
     cm = CorpusManager(corpus_dir)

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/corpus_cleanup.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/corpus_cleanup.py
@@ -4,11 +4,7 @@ from pathlib import Path
 import sys
 import os
 
-try:
-    from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
-except ImportError:
-    sys.path.append(str(Path(__file__).resolve().parent.parent))
-    from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
+from shared_tools.storage.corpus_manager import CorpusManager
 
 def cleanup_corpus(corpus_dir, metadata_path=None, dry_run=False):
     corpus_dir = Path(corpus_dir)

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/corpus_integrity_check.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/corpus_integrity_check.py
@@ -4,11 +4,7 @@ from pathlib import Path
 import sys
 import os
 
-try:
-    from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
-except ImportError:
-    sys.path.append(str(Path(__file__).resolve().parent.parent))
-    from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
+from shared_tools.storage.corpus_manager import CorpusManager
 
 try:
     from PyPDF2 import PdfReader

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/recover_orphaned_txts.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/recover_orphaned_txts.py
@@ -4,11 +4,7 @@ from pathlib import Path
 import sys
 import shutil
 
-try:
-    from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
-except ImportError:
-    sys.path.append(str(Path(__file__).resolve().parent.parent))
-    from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
+from shared_tools.storage.corpus_manager import CorpusManager
 
 def recover_orphaned_txts(corpus_dir, metadata_path, priority_stems=None, dry_run=False):
     corpus_dir = Path(corpus_dir)

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/tag_priority_high.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/tag_priority_high.py
@@ -3,11 +3,7 @@ import json
 from pathlib import Path
 import sys
 
-try:
-    from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
-except ImportError:
-    sys.path.append(str(Path(__file__).resolve().parent.parent))
-    from CryptoFinanceCorpusBuilder.storage.corpus_manager import CorpusManager
+from shared_tools.storage.corpus_manager import CorpusManager
 
 def tag_priority_high(corpus_dir, metadata_path, stems=None, titles=None, get_doc_stem=None):
     stems = set(stems or [])


### PR DESCRIPTION
## Summary
- update paths importing `CorpusManager` to use the shared_tools package
- drop old try/except fallbacks for earlier package layout

## Testing
- `python -m py_compile CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/corpus_manager/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: fitz, dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68442d934e748326adf7626b3c2cf0e5