### PR TITLE
Rename package from CryptoFinanceCorpusBuilder to corpusbuilder

### DIFF
--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/__init__.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/__init__.py
@@ -1,5 +1,5 @@
 """
-CryptoFinanceCorpusBuilder application package.
+CorpusBuilder — modern crypto corpus suite.
 """
 
-# CryptoFinanceCorpusBuilder package root 
+# corpusbuilder package root

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/README_JUNE.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/README_JUNE.md
@@ -40,7 +40,7 @@ Required packages include:
 
 ## Project Structure
 ```
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
 ├── config/
 │   ├── master_config.yaml           # Main configuration file
 │   ├── domain_config.py             # Domain definitions
@@ -61,15 +61,15 @@ CryptoFinanceCorpusBuilder/
 
 ### 1. Configuration System
 The system uses a centralized configuration management through `ProjectConfig`:
-- Located in: `CryptoFinanceCorpusBuilder/shared_tools/project_config.py`
-- Main config file: `CryptoFinanceCorpusBuilder/config/master_config.yaml`
+- Located in: `corpusbuilder/shared_tools/project_config.py`
+- Main config file: `corpusbuilder/config/master_config.yaml`
 - Environment-specific settings for production and test environments
 - Domain-specific configurations for different crypto-finance topics
 
 ### 2. Collection Pipeline
 
 #### 2.1 Collectors
-Located in: `CryptoFinanceCorpusBuilder/shared_tools/collectors/`
+Located in: `corpusbuilder/shared_tools/collectors/`
 
 ##### a) SciDB Collector (`enhanced_scidb_collector.py`)
 - **Purpose**: Collects academic papers from SciDB
@@ -129,7 +129,7 @@ Located in: `CryptoFinanceCorpusBuilder/shared_tools/collectors/`
 ### 3. Processing Pipeline
 
 #### 3.1 Extractors
-Located in: `CryptoFinanceCorpusBuilder/shared_tools/processors/`
+Located in: `corpusbuilder/shared_tools/processors/`
 
 ##### a) PDF Extractor
 - **Purpose**: Extracts text from PDF documents
@@ -256,7 +256,7 @@ Located in: `CryptoFinanceCorpusBuilder/shared_tools/processors/`
 ### 4. Storage and Management
 
 #### 4.1 Corpus Manager (`corpus_manager.py`)
-Located in: `CryptoFinanceCorpusBuilder/shared_tools/storage/`
+Located in: `corpusbuilder/shared_tools/storage/`
 
 - **Purpose**: Manages corpus structure and metadata
 - **Features**:
@@ -283,7 +283,7 @@ Located in: `CryptoFinanceCorpusBuilder/shared_tools/storage/`
 1. **Clone and Install**:
    ```bash
    git clone [repository_url]
-   cd CryptoFinanceCorpusBuilder
+   cd corpusbuilder
    pip install -r requirements.txt
    ```
 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/CANONICAL_ENTRY_POINTS.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/CANONICAL_ENTRY_POINTS.md
@@ -94,7 +94,7 @@ python -m CryptoFinanceCorpusBuilder.utils.verify_install
 ## Notes
 
 1. All paths should be absolute or relative to the project root
-2. Configuration files should be placed in `CryptoFinanceCorpusBuilder/config/`
-3. Logs are automatically written to `CryptoFinanceCorpusBuilder/logs/`
-4. Temporary files are stored in `CryptoFinanceCorpusBuilder/temp_workers/`
+2. Configuration files should be placed in `corpusbuilder/config/`
+3. Logs are automatically written to `corpusbuilder/logs/`
+4. Temporary files are stored in `corpusbuilder/temp_workers/`
 5. All scripts support `--help` for detailed usage information 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/CONVO.TXT
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/CONVO.TXT
@@ -805,7 +805,7 @@ Would you like me to provide more details about any specific component of this i
 
 
 
-Ran tool Read file: CryptoFinanceCorpusBuilder/processors/batch_nonpdf_extractor.py Read file: CryptoFinanceCorpusBuilder/processors/batch_nonpdf_extractor.py Read file: CryptoFinanceCorpusBuilder/processors/batch_nonpdf_extractor.py Ran tool Read file: CryptoFinanceCorpusBuilder/processors/ba
+Ran tool Read file: corpusbuilder/processors/batch_nonpdf_extractor.py Read file: corpusbuilder/processors/batch_nonpdf_extractor.py Read file: corpusbuilder/processors/batch_nonpdf_extractor.py Ran tool Read file: corpusbuilder/processors/ba
 
 pasted
 
@@ -1109,7 +1109,7 @@ Flag machine-translated content which often has lower quality signal
 
 
 
-This approach preserves valuable non-English resources while preventing excessive token budget allocation to non-core materials.RetrySRead file: CryptoFinanceCorpusBuilder/cli/collectors/collect_annas_main_library.py
+This approach preserves valuable non-English resources while preventing excessive token budget allocation to non-core materials.RetrySRead file: corpusbuilder/cli/collectors/collect_annas_main_library.py
 Here’s what’s happening in the filtering and quality logic for "The Black Swan":
 ---
 ### Current Filtering/Quality Logic
@@ -1187,7 +1187,7 @@ This fix will immediately improve our ability to reach the 60/40 target distribu
 System-Level Quality Control Architecture
 
 Create a centralized QualityControlService:
-/workspace/CryptoFinanceCorpusBuilder/processors/quality_control.py
+/workspace/corpusbuilder/processors/quality_control.py
 
 Design a configurable content evaluator:
 
@@ -1211,7 +1211,7 @@ Pass document context (domain, source) to the quality controller
 
 
 
-This system-level approach gives you consistent quality control across all collectors while adapting criteria based on domain context - ensuring both crypto and traditional finance materials are evaluated appropriately for the 60/40 split.RetrySregarding non pdf extractionA new script, batch_nonpdf_extractor.py, has been created in CryptoFinanceCorpusBuilder/processors/ with the following features:
+This system-level approach gives you consistent quality control across all collectors while adapting criteria based on domain context - ensuring both crypto and traditional finance materials are evaluated appropriately for the 60/40 split.RetrySregarding non pdf extractionA new script, batch_nonpdf_extractor.py, has been created in corpusbuilder/processors/ with the following features:
 - Automatic file type detection for .py, .ipynb, .md, .html, .htm, .json, and .csv.
 - Extraction logic for each type:
   - Python: code, comments, docstrings
@@ -1224,7 +1224,7 @@ This system-level approach gives you consistent quality control across all colle
 - Metadata: Language, quality flag, file type, original path, extraction date, token count
 - CLI usage:  
   
-  python CryptoFinanceCorpusBuilder/processors/batch_nonpdf_extractor.py --input-dir <input> --output-dir <output>
+  python corpusbuilder/processors/batch_nonpdf_extractor.py --input-dir <input> --output-dir <output>
   
 You can now test this script on your sample data in data/test_collect/.  
 Would you like a sample command or further customization (e.g., advanced quality scoring, duplicate detection)?please rreview and reply > do we want more customization? brief and to the point without missing critical elementsEditReview: Non-PDF Extraction Script
@@ -1270,7 +1270,7 @@ Add domain-aware scoring immediately after validation
 Implement chunking next
 Add duplicate detection last
 
-This prioritizes the features most essential for maintaining corpus quality while allowing for immediate testing. Full alignment with PDF extraction can be achieved through these targeted enhancements without delaying progress.Retry(dedup_venv) PS G:\ai_trading_dev> python CryptoFinanceCorpusBuilder/processors/batch_nonpdf_extractor.py --input-dir data/test_collect/bitmex/bitmex_research --output-dir data/test_collect/bitmex/bitmex_research
+This prioritizes the features most essential for maintaining corpus quality while allowing for immediate testing. Full alignment with PDF extraction can be achieved through these targeted enhancements without delaying progress.Retry(dedup_venv) PS G:\ai_trading_dev> python corpusbuilder/processors/batch_nonpdf_extractor.py --input-dir data/test_collect/bitmex/bitmex_research --output-dir data/test_collect/bitmex/bitmex_research
 Processing: bitmex_research.html
 G:\ai_trading_dev\CryptoFinanceCorpusBuilder\processpastedSDISREGARD THE PICTUREmessage from dev below I will begin preparing the domain relevance scoring enhancement for the extractor, as discussed.
 Would you like to prioritize any specific file type for the next copy, or proceed with all types in parallel?
@@ -1299,7 +1299,7 @@ Proceed with implementation while building out the test suite in parallel for ef
 Design & Implementation Plan
 1. Domain Keyword Source
 * Use the same logic as DomainClassifier:
-* Load domain config from CryptoFinanceCorpusBuilder/config/domain_config.py (or inline if not present).
+* Load domain config from corpusbuilder/config/domain_config.py (or inline if not present).
 * Extract keywords for each domain from the search_terms field.
 2. CLI & Inference
 * Add a --domain parameter to the extractor script.
@@ -1339,12 +1339,12 @@ Add domain relevance data without changing existing metadata format
 
 
 This gives us the fastest path to implementation while maintaining alignment with the PDF pipeline. Focus on getting a working version that we can test with real files.RetrySRan tool
-Read file: CryptoFinanceCorpusBuilder/config/domain_config.py
+Read file: corpusbuilder/config/domain_config.py
 Perfect. Here’s how I’ll proceed for domain relevance scoring in the extractor:
 ---
 ## Implementation Plan (Direct Approach)
 ### 1. Source Keywords
-- Import DOMAINS from CryptoFinanceCorpusBuilder/config/domain_config.py.
+- Import DOMAINS from corpusbuilder/config/domain_config.py.
 - For each domain, use the search_terms list as the canonical keyword set.
 ### 2. CLI & Inference
 - Add a --domain parameter (accepts any of the 8 domains).
@@ -1724,13 +1724,13 @@ Ran tool
 Ran tool
 Ran tool
 Ran tool
-Read file: CryptoFinanceCorpusBuilder/processors/deduplicator.py
+Read file: corpusbuilder/processors/deduplicator.py
 Summary of Findings and Next Actions:
 ### 1. Familiarization & Project Rules
 - The project README and chunking test README have been thoroughly reviewed.
 - Key rules: All logic must be modular, test-driven, and collector-specific. No global/shared logic changes unless absolutely necessary. All new features must be testable and documented.
 ### 2. Existing Deduplication Logic
-- There is a robust, modular deduplication system in CryptoFinanceCorpusBuilder/processors/deduplicator.py:
+- There is a robust, modular deduplication system in corpusbuilder/processors/deduplicator.py:
   - Exact duplicate detection via file hash (MD5).
   - Near-duplicate detection via MinHash/LSH (configurable threshold, default 0.8).
   - Title-based duplicate detection (normalized titles).
@@ -1765,7 +1765,7 @@ Next Step Actions:
 2. If approved, integrate the deduplication system as a post-extraction step for non-PDFs, updating metadata as needed.
 3. Add/extend tests in the chunking pipeline to cover deduplication for all supported file types and edge cases.
 Ready to proceed as soon as you confirm or clarify the above points!please reply briefly and to the point without missing critical elementsthe technical summary of current deduplicator (its good as it is) I think Certainly! Here’s a concise technical summary of the deduplication system for your reference:---## Technical Summary: Deduplication SystemLocation:  
-CryptoFinanceCorpusBuilder/processors/deduplicator.py### Core FeaturesExact Duplicate Detection
+corpusbuilder/processors/deduplicator.py### Core FeaturesExact Duplicate Detection
 Uses MD5 hash of file contents to identify files with identical content.Maintains a mapping of file hashes to file paths.Groups all files with the same hash as exact duplicates.Near-Duplicate Detection (MinHash/LSH)
 Uses the datasketch library’s MinHash and LSH (Locality Sensitive Hashing) to detect files with high content similarity (default threshold: 0.8).Shingles (substrings) are created from file text, and MinHash signatures are computed.LSH is used to efficiently find groups of files with similar content, even if not byte-for-byte identical (e.g., minor edits, formatting changes).Title-Based Duplicate Detection
 Extracts and normalizes document titles (from metadata or filenames).Groups files with the same normalized title but different content hashes as potential duplicates.Indexing & Reporting
@@ -1895,7 +1895,7 @@ token_loss: Number of tokens "lost" if this file is a duplicate
 
 
 The token loss calculation is particularly important for corpus balance tracking. Implement using the same logic as the PDF pipeline.RetrySRan tool
-Read file: CryptoFinanceCorpusBuilder/processors/deduplicator.py
+Read file: corpusbuilder/processors/deduplicator.py
 Analysis of PDF Deduplicator Alignment:
 ### What the PDF Deduplicator Does:
 - Token Loss Reporting:  
@@ -3123,7 +3123,7 @@ Final review and launch
 
 Key Files and Directories
 
-Main code: CryptoFinanceCorpusBuilder/
+Main code: corpusbuilder/
 Extraction: processors/batch_pdf_extractor.py and processors/batch_nonpdf_extractor.py
 Analytics: analytics/corpus_balance_analyzer.py
 Config: config/enhanced_sources.json
@@ -3315,10 +3315,10 @@ Path format issues (Windows vs Unix paths)
 Case sensitivity issues (e.g., "Crypto_Derivatives" vs "crypto_derivatives")
 Directory structure not matching expectations
 
-Let me know the debug output, and I can provide a more targeted fix if needed.RetrySRead file: CryptoFinanceCorpusBuilder/README FULL.md
-Read file: CryptoFinanceCorpusBuilder/utils/domain_utils.py
-Read file: CryptoFinanceCorpusBuilder/processors/batch_text_extractor.py
-Read file: CryptoFinanceCorpusBuilder/processors/batch_text_extractor.py
+Let me know the debug output, and I can provide a more targeted fix if needed.RetrySRead file: corpusbuilder/README FULL.md
+Read file: corpusbuilder/utils/domain_utils.py
+Read file: corpusbuilder/processors/batch_text_extractor.py
+Read file: corpusbuilder/processors/batch_text_extractor.py
 ### Deep Audit: Domain Assignment Issue
 #### 1. README & Boss Guidance
 - The README and boss both require robust, multi-strategy domain assignment:
@@ -3503,7 +3503,7 @@ Once verified, continue to the remaining integration tasks
 
 Files to Modify
 
-CryptoFinanceCorpusBuilder/utils/domain_utils.py (primary fix)
-CryptoFinanceCorpusBuilder/processors/batch_text_extractor.py (update calls with debug flag)
+corpusbuilder/utils/domain_utils.py (primary fix)
+corpusbuilder/processors/batch_text_extractor.py (update calls with debug flag)
 
 The current focus is at Step 1 (Integration Testing & Validation) of our 5-step launch plan. Once the domain assignment is fixed, we'll complete integration testing and move to downstream integration.

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/README FULL.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/README FULL.md
@@ -341,7 +341,7 @@ For more details, see the CLI help or the relevant section above. If you add a n
 
 **As of the latest refactor, all collector logic is now fully modularized.**
 
-- Each collector (ISDA, BitMEX, Anna's Archive, General Web Corpus, etc.) has its own file in `CryptoFinanceCorpusBuilder/cli/` (e.g., `collect_isda.py`, `collect_bitmex.py`, etc.).
+- Each collector (ISDA, BitMEX, Anna's Archive, General Web Corpus, etc.) has its own file in `corpusbuilder/cli/` (e.g., `collect_isda.py`, `collect_bitmex.py`, etc.).
 - The main CLI (`crypto_corpus_cli.py`) only dispatches to these per-collector modules. No collector logic lives in the CLI itself.
 - All logic, imports, config, and CLI flag parsing for each collector is self-contained in its own file.
 - No shared logic or base classes are used for collectors. All changes are per-collector and isolated.
@@ -356,7 +356,7 @@ For more details, see the CLI help or the relevant section above. If you add a n
 
 **Example File Structure:**
 ```
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
   cli/
     crypto_corpus_cli.py
     collect_isda.py
@@ -419,7 +419,7 @@ python -m CryptoFinanceCorpusBuilder.cli.crypto_corpus_cli collect --help
 ```
 
 ## Modular Collector Logic
-- All collector logic is now in `CryptoFinanceCorpusBuilder/cli/collectors/` as `collect_<name>.py` files.
+- All collector logic is now in `corpusbuilder/cli/collectors/` as `collect_<name>.py` files.
 - The CLI only dispatches to these per-collector modules.
 - No collector logic lives in the CLI itself.
 - All logic, imports, config, and CLI flag parsing for each collector is self-contained in its own file.
@@ -434,7 +434,7 @@ python -m CryptoFinanceCorpusBuilder.cli.crypto_corpus_cli collect --help
 Currently, **text extraction from PDFs (to populate the `_extracted` folders for monitoring and downstream tasks) is NOT automated as part of the corpus collection workflow**. After collecting PDFs, you must run the extraction manually using the batch extraction script:
 
 ```sh
-python CryptoFinanceCorpusBuilder/processors/batch_text_extractor.py
+python corpusbuilder/processors/batch_text_extractor.py
 ```
 
 - By default, this script processes `data/corpus_1`. To use it with test folders, modify the `corpus_dir` variable at the top of the script to point to your test directory (e.g., `data/test_collect`).
@@ -643,7 +643,7 @@ python -m CryptoFinanceCorpusBuilder.cli.crypto_corpus_cli collect_annas --batch
 - **Title cache:** `data/title_cache_<YYYYMMDD>.txt`
 - **Main corpus:** `data/corpus_1/corpus_all.csv`
 - **Extraction script:** `scripts/extract_title_cache.py`
-- **Collector logic:** `CryptoFinanceCorpusBuilder/cli/collectors/collect_annas_main_library.py` (and similar for other collectors)
+- **Collector logic:** `corpusbuilder/cli/collectors/collect_annas_main_library.py` (and similar for other collectors)
 
 ---
 
@@ -1421,14 +1421,14 @@ $env:PYTHONPATH="G:\ai_trading_dev"
 
 ## 5. Ensure All Folders Have `__init__.py`
 Place an (even empty) `__init__.py` file in:
-- `CryptoFinanceCorpusBuilder/`
-- `CryptoFinanceCorpusBuilder/processors/`
-- `CryptoFinanceCorpusBuilder/tests/`
-- `CryptoFinanceCorpusBuilder/tests/pdf_extraction/`
+- `corpusbuilder/`
+- `corpusbuilder/processors/`
+- `corpusbuilder/tests/`
+- `corpusbuilder/tests/pdf_extraction/`
 
 ## 6. Run All Tests End-to-End
 ```bash
-pytest -s CryptoFinanceCorpusBuilder/tests/
+pytest -s corpusbuilder/tests/
 ```
 
 ---
@@ -1649,11 +1649,11 @@ To run the test suites:
 
 ```bash
 # Run all tests
-python -m unittest discover CryptoFinanceCorpusBuilder/tests
+python -m unittest discover corpusbuilder/tests
 
 # Run specific test suite
-python -m unittest CryptoFinanceCorpusBuilder/tests/test_processors.py
-python -m unittest CryptoFinanceCorpusBuilder/tests/test_collectors.py
+python -m unittest corpusbuilder/tests/test_processors.py
+python -m unittest corpusbuilder/tests/test_collectors.py
 ```
 
 ## Test Data Requirements
@@ -1672,7 +1672,7 @@ When adding new test files:
 
 The project includes several test suites organized by functionality and scope:
 
-### 1. Core Test Suites (CryptoFinanceCorpusBuilder/tests/)
+### 1. Core Test Suites (corpusbuilder/tests/)
 - **test_processors.py**
   - Tests text extraction from various file types (text, markdown, notebooks)
   - Tests domain classification functionality
@@ -1730,12 +1730,12 @@ The project includes several test suites organized by functionality and scope:
     - GitHub collector
 
 ### 4. Test Data
-- **integration_pdfs/** (CryptoFinanceCorpusBuilder/tests/)
+- **integration_pdfs/** (corpusbuilder/tests/)
   - Large collection of real-world PDFs
   - Used for integration testing
   - Contains various document types
 
-- **integration_pdfs_small/** (CryptoFinanceCorpusBuilder/tests/)
+- **integration_pdfs_small/** (corpusbuilder/tests/)
   - Smaller subset for quick testing
   - Representative samples of different types
   - Ideal for development and verification
@@ -1754,11 +1754,11 @@ The project includes several test suites organized by functionality and scope:
 ### Run All Tests
 ```bash
 # Run all test suites
-python -m unittest discover CryptoFinanceCorpusBuilder/tests
+python -m unittest discover corpusbuilder/tests
 
 # Run specific test suite
-python -m unittest CryptoFinanceCorpusBuilder/tests/test_processors.py
-python -m unittest CryptoFinanceCorpusBuilder/tests/test_collectors.py
+python -m unittest corpusbuilder/tests/test_processors.py
+python -m unittest corpusbuilder/tests/test_collectors.py
 ```
 
 ### Run Integration Tests

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/README.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/README.md
@@ -7,7 +7,7 @@ This project provides a modular, extensible framework for building, managing, an
 ## Directory Structure
 
 ```
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
 │
 ├── cli/                           # Command-line interface (CLI) entry point
 ├── config/                        # Configuration files and settings
@@ -53,7 +53,7 @@ CryptoFinanceCorpusBuilder/
 ### Collecting Data from a Source
 
 ```bash
-python -m CryptoFinanceCorpusBuilder.cli.crypto_corpus_cli collect --sources arxiv github --config CryptoFinanceCorpusBuilder/config/enhanced_sources.json --output-dir data/corpus_1
+python -m CryptoFinanceCorpusBuilder.cli.crypto_corpus_cli collect --sources arxiv github --config corpusbuilder/config/enhanced_sources.json --output-dir data/corpus_1
 ```
 
 Or, since enhanced_sources.json is now the default:

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/README_collectors.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/README_collectors.md
@@ -513,7 +513,7 @@ AA_ACCOUNT_COOKIE=your_annas_archive_cookie
 
 
 Directory Structure
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
 ├── sources/                   # Source collectors
 │   ├── __init__.py            # Package init (IMPORTANT!)
 │   ├── base_collector.py      # Base collector class

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/README_command lines.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/README_command lines.md
@@ -7,7 +7,7 @@ This project provides a modular, extensible framework for building, managing, an
 ## Directory Structure
 
 ```
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
 │
 ├── cli/                           # Command-line interface (CLI) entry point
 ├── config/                        # Configuration files and settings
@@ -53,7 +53,7 @@ CryptoFinanceCorpusBuilder/
 ### Collecting Data from a Source
 
 ```bash
-python -m CryptoFinanceCorpusBuilder.cli.crypto_corpus_cli collect --sources arxiv github --config CryptoFinanceCorpusBuilder/config/enhanced_sources.json --output-dir data/corpus_1
+python -m CryptoFinanceCorpusBuilder.cli.crypto_corpus_cli collect --sources arxiv github --config corpusbuilder/config/enhanced_sources.json --output-dir data/corpus_1
 ```
 
 Or, since enhanced_sources.json is now the default:

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/balancer integration guide and examples.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/balancer integration guide and examples.md
@@ -19,7 +19,7 @@ The Corpus Balancer integrates with your existing architecture at several key po
 ### Directory Structure
 
 ```
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
 ├── processors/
 │   ├── corpus_balancer.py          # Core balancer module
 │   ├── base_extractor.py           # Existing - unchanged

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/pyproject.toml
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "CryptoFinanceCorpusBuilder"
+name = "corpusbuilder"
 version = "0.1.0"
 description = "A modular framework for building and managing a crypto-finance document corpus."
 authors = [

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/Readme_TESTS.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/Readme_TESTS.md
@@ -62,7 +62,7 @@ Before running the tests, ensure you have:
 
 ### Directory Structure
 ```
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
 ├── tests/
 │   └── ProjectConfigCollectorTests/
 │       ├── test_arxiv_collector.py
@@ -75,7 +75,7 @@ CryptoFinanceCorpusBuilder/
 The simplest way to run all tests is using the test runner. First, navigate to the test directory:
 
 ```powershell
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 ```
 
 Then run:
@@ -90,7 +90,7 @@ You have two options to run individual tests:
 1. **From the test directory** (recommended):
    ```powershell
    # First, change to the test directory
-   cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+   cd corpusbuilder/tests/ProjectConfigCollectorTests
    
    # Then run the test
    pytest test_arxiv_collector.py -v
@@ -98,7 +98,7 @@ You have two options to run individual tests:
 
 2. **From the project root** (using full path):
    ```powershell
-   pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_arxiv_collector.py -v
+   pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_arxiv_collector.py -v
    ```
 
 ### Running All Tests
@@ -106,7 +106,7 @@ You have two options to run individual tests:
 To run all collector tests, first ensure you're in the test directory:
 
 ```powershell
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest *.py -v
 ```
 
@@ -137,7 +137,7 @@ Tests use the `test_config.yaml` file, which specifies:
 Common issues and solutions:
 
 1. **Test Not Found Error**:
-   - Ensure you're in the correct directory (`CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests`)
+   - Ensure you're in the correct directory (`corpusbuilder/tests/ProjectConfigCollectorTests`)
    - Or use the full path to the test file
    - Check that the test file exists in the directory
 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/commands_tests.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/commands_tests.md
@@ -5,110 +5,110 @@
 ### SciDB Collector >tested
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_scidb_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_scidb_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest test_scidb_collector.py -v
 ```
 
 ### Arxiv Collector >tested 
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_arxiv_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_arxiv_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest test_arxiv_collector.py -v
 ```
 
 ### GitHub Collector
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_github_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_github_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_github_collector.py -v
+cd corpusbuilder/tests/ProjectConfigCollectorTests
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_github_collector.py -v
 ```
 
 ### API Collector
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_api_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_api_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest test_api_collector.py -v
 ```
 
 ### BitMEX Collector
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_bitmex_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_bitmex_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest test_bitmex_collector.py -v
 ```
 
 ### General Web Collector
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_general_web_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_general_web_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest test_general_web_collector.py -v
 ```
 
 ### ISDA Collector
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_isda_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_isda_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest test_isda_collector.py -v
 ```
 
 ### FRED Collector
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_fred_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_fred_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest test_fred_collector.py -v
 ```
 
 ### Quantopian Collector
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_quantopian_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_quantopian_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest test_quantopian_collector.py -v
 ```
 
 ### Repo Collector
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_repo_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_repo_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest test_repo_collector.py -v
 ```
 
 ### Web Collector
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/test_web_collector.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/test_web_collector.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest test_web_collector.py -v
 ```
 
@@ -129,20 +129,20 @@ pytest test_web_collector.py -v
 ### Using Test Runner
 ```powershell
 # From project root
-python CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/run_collector_tests.py
+python corpusbuilder/tests/ProjectConfigCollectorTests/run_collector_tests.py
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 python run_collector_tests.py
 ```
 
 ### Using Pytest Directly
 ```powershell
 # From project root
-pytest CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests/*.py -v
+pytest corpusbuilder/tests/ProjectConfigCollectorTests/*.py -v
 
 # From test directory
-cd CryptoFinanceCorpusBuilder/tests/ProjectConfigCollectorTests
+cd corpusbuilder/tests/ProjectConfigCollectorTests
 pytest *.py -v
 ```
 

--- a/CorpusBuilderApp/app/__init__.py
+++ b/CorpusBuilderApp/app/__init__.py
@@ -1,3 +1,3 @@
 """
-CryptoFinanceCorpusBuilder application package.
-""" 
+CorpusBuilder — modern crypto corpus suite.
+"""

--- a/CorpusBuilderApp/docs/DEVELOPER_GUIDE.md
+++ b/CorpusBuilderApp/docs/DEVELOPER_GUIDE.md
@@ -15,7 +15,7 @@
 ## Project Structure
 
 ```
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
 ├── app/                  # Main application code
 │   ├── main.py
 │   ├── main_window.py

--- a/CorpusBuilderApp/docs/deprecated/README.md
+++ b/CorpusBuilderApp/docs/deprecated/README.md
@@ -52,8 +52,8 @@ The CryptoFinance Corpus Builder is a PyQt6-based desktop application designed t
 ### Setup
 
 1. Clone the repository:
-git clone https://github.com/your-username/CryptoFinanceCorpusBuilder.git
-cd CryptoFinanceCorpusBuilder
+git clone https://github.com/your-username/corpusbuilder.git
+cd corpusbuilder
 
 
 2. Install dependencies:
@@ -110,7 +110,7 @@ python app/main.py
 
 ## Project Structure
 
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
 ├── app/ # Application code
 │ ├── main.py # Entry point
 │ ├── ui/ # User interface components

--- a/CorpusBuilderApp/docs/deprecated/README_1.md
+++ b/CorpusBuilderApp/docs/deprecated/README_1.md
@@ -205,7 +205,7 @@ pytest tests/ui/ --qt-api pyqt6
 ## 📁 Project Structure
 
 ```
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
 ├── app/                          # Main application
 │   ├── main.py                   # Entry point
 │   ├── main_window.py            # Main window

--- a/CorpusBuilderApp/docs/readme.md
+++ b/CorpusBuilderApp/docs/readme.md
@@ -26,8 +26,8 @@ A professional-grade PyQt6 desktop application for building, managing, and analy
 ### Installation
 
 ```bash
-git clone https://github.com/your-org/CryptoFinanceCorpusBuilder.git
-cd CryptoFinanceCorpusBuilder
+git clone https://github.com/your-org/corpusbuilder.git
+cd corpusbuilder
 python -m venv venv  # or python3 -m venv venv
 venv\Scripts\activate  # Windows
 # or

--- a/CorpusBuilderApp/docs/test_guide.md
+++ b/CorpusBuilderApp/docs/test_guide.md
@@ -23,32 +23,32 @@ The table below lists all test modules and the directories or inputs they expect
 
 | Test File | Required Folder or Input | Description |
 |-----------|-------------------------|-------------|
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_annas_library_collector.py | AA_ACCOUNT_COOKIE env var, config/test_config.yaml | Downloads PDFs from Anna's Archive |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_api_collector.py | None (uses temp dirs) | Exercises generic API collector |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_arxiv_collector.py | Internet access, config/test_config.yaml | Collects papers from arXiv |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_arxiv_collector_projectconfig.py | config/master_config.yaml | Arxiv collector with ProjectConfig |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_bitmex_collector.py | mock_bitmex_research.html file | Parses BitMEX research posts |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_chunking_behavior.py | data/test_collect/chunking_tests/* | Chunking of CSV/py/ipynb/JSON files |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_domain_config_wrapper.py | None | Domain config wrapper logic |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_fred_collector.py | FRED_API_KEY env var, config/test_config.yaml | Downloads data from FRED |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_general_web_collector.py | None | Web scraping collector |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_github_collector.py | GitHub token env var, output dir | Clones GitHub repos |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_github_collector_projectconfig.py | master_config.yaml | GitHub collector with ProjectConfig |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_isda_collector.py | None | ISDA website collector |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_pdf_extractor.py | tests/pdf_extraction/test_pdfs/ | Runs real PDF extraction |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_processors.py | None | Processor integration tests |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_quantopian_collector.py | None | Quantopian data collector |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_repo_collector.py | config/test_config.yaml | Repository collector downloads |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_scidb_collector.py | SciDB credentials | SciDB data fetch |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_scidb_collector_projectconfig.py | master_config.yaml | SciDB collector with ProjectConfig |
-| CryptoFinanceCorpusBuilder/tests/deprecated/test_web_collector.py | None | Generic website scraping |
-| CryptoFinanceCorpusBuilder/tests/test_base_extractor.py | temp input/output dirs with sample text | Base extractor pipeline |
-| CryptoFinanceCorpusBuilder/tests/test_bitmex_collector.py | mock_bitmex_research.html | Old BitMEX collector |
-| CryptoFinanceCorpusBuilder/tests/test_collectors.py | temp dirs | Basic collector behaviours |
-| CryptoFinanceCorpusBuilder/tests/test_corpus_balance.py | temp corpus with _extracted & low_quality | Corpus balancing analysis |
-| CryptoFinanceCorpusBuilder/tests/test_extractor_utils.py | temp files | Utility functions |
-| CryptoFinanceCorpusBuilder/tests/test_quality_config.py | config/quality_control_config.json | Model config validation |
-| CryptoFinanceCorpusBuilder/tests/test_quality_control_config.py | config/quality_control_config.json | Quality control config validation |
+| corpusbuilder/tests/deprecated/test_annas_library_collector.py | AA_ACCOUNT_COOKIE env var, config/test_config.yaml | Downloads PDFs from Anna's Archive |
+| corpusbuilder/tests/deprecated/test_api_collector.py | None (uses temp dirs) | Exercises generic API collector |
+| corpusbuilder/tests/deprecated/test_arxiv_collector.py | Internet access, config/test_config.yaml | Collects papers from arXiv |
+| corpusbuilder/tests/deprecated/test_arxiv_collector_projectconfig.py | config/master_config.yaml | Arxiv collector with ProjectConfig |
+| corpusbuilder/tests/deprecated/test_bitmex_collector.py | mock_bitmex_research.html file | Parses BitMEX research posts |
+| corpusbuilder/tests/deprecated/test_chunking_behavior.py | data/test_collect/chunking_tests/* | Chunking of CSV/py/ipynb/JSON files |
+| corpusbuilder/tests/deprecated/test_domain_config_wrapper.py | None | Domain config wrapper logic |
+| corpusbuilder/tests/deprecated/test_fred_collector.py | FRED_API_KEY env var, config/test_config.yaml | Downloads data from FRED |
+| corpusbuilder/tests/deprecated/test_general_web_collector.py | None | Web scraping collector |
+| corpusbuilder/tests/deprecated/test_github_collector.py | GitHub token env var, output dir | Clones GitHub repos |
+| corpusbuilder/tests/deprecated/test_github_collector_projectconfig.py | master_config.yaml | GitHub collector with ProjectConfig |
+| corpusbuilder/tests/deprecated/test_isda_collector.py | None | ISDA website collector |
+| corpusbuilder/tests/deprecated/test_pdf_extractor.py | tests/pdf_extraction/test_pdfs/ | Runs real PDF extraction |
+| corpusbuilder/tests/deprecated/test_processors.py | None | Processor integration tests |
+| corpusbuilder/tests/deprecated/test_quantopian_collector.py | None | Quantopian data collector |
+| corpusbuilder/tests/deprecated/test_repo_collector.py | config/test_config.yaml | Repository collector downloads |
+| corpusbuilder/tests/deprecated/test_scidb_collector.py | SciDB credentials | SciDB data fetch |
+| corpusbuilder/tests/deprecated/test_scidb_collector_projectconfig.py | master_config.yaml | SciDB collector with ProjectConfig |
+| corpusbuilder/tests/deprecated/test_web_collector.py | None | Generic website scraping |
+| corpusbuilder/tests/test_base_extractor.py | temp input/output dirs with sample text | Base extractor pipeline |
+| corpusbuilder/tests/test_bitmex_collector.py | mock_bitmex_research.html | Old BitMEX collector |
+| corpusbuilder/tests/test_collectors.py | temp dirs | Basic collector behaviours |
+| corpusbuilder/tests/test_corpus_balance.py | temp corpus with _extracted & low_quality | Corpus balancing analysis |
+| corpusbuilder/tests/test_extractor_utils.py | temp files | Utility functions |
+| corpusbuilder/tests/test_quality_config.py | config/quality_control_config.json | Model config validation |
+| corpusbuilder/tests/test_quality_control_config.py | config/quality_control_config.json | Quality control config validation |
 | tests/deprecated/test_corpus_management.py | temp corpus directories with sample file | Corpus manager UI integration |
 | tests/deprecated/test_data_collectors.py | API keys env vars; network access | Collector behaviours across services |
 | tests/deprecated/test_ui_integration.py | PySide6 installed | Basic UI widget integration |

--- a/CorpusBuilderApp/setup-and-docs.md
+++ b/CorpusBuilderApp/setup-and-docs.md
@@ -348,7 +348,7 @@ pytest tests/ui/ --qt-api pyqt6
 ## Directory Structure
 
 ```
-CryptoFinanceCorpusBuilder/
+corpusbuilder/
 ├── app/                          # Main application code
 │   ├── main.py                   # Application entry point
 │   ├── main_window.py            # Main window class

--- a/CorpusBuilderApp/setup.py
+++ b/CorpusBuilderApp/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="CryptoFinanceCorpusBuilder",
+    name="corpusbuilder",
     version="3.0.0",
     description="A desktop application for building and managing a crypto-finance corpus",
     author="Your Name",


### PR DESCRIPTION
## Summary
- rename `CryptoFinanceCorpusBuilder` package to `corpusbuilder` in setup and pyproject
- update module docstrings to reflect new name
- adjust documentation references and paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68442d100b248326aabccff38c76d4be