### PR TITLE
Rename DomainConfig helper to DomainKeywordHelper

### DIFF
--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_utils/domain_utils.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/prev_working_utils/domain_utils.py
@@ -32,7 +32,7 @@ DOMAIN_KEYWORDS = {
     # Add more as needed
 }
 
-class DomainConfig:
+class DomainKeywordHelper:
     """Configuration wrapper for domain settings with fallback mechanisms."""
     
     def __init__(self, config_path: Optional[str] = None):
@@ -77,12 +77,12 @@ class DomainConfig:
         return self.keywords
 
 # Initialize default config
-_domain_config = DomainConfig()
+_domain_helper = DomainKeywordHelper()
 
 # Keep existing functions as wrappers for backward compatibility
 def get_valid_domains():
     """Get list of valid domains (backward compatible)."""
-    return _domain_config.get_valid_domains()
+    return _domain_helper.get_valid_domains()
 
 def get_domain_for_file(file_path, text=None, debug=False):
     """
@@ -146,7 +146,7 @@ def get_domain_for_file(file_path, text=None, debug=False):
                 return assigned_domain
     # 4. Keyword matching (filename/text)
     fname = os.path.basename(file_path_str).lower()
-    for dom, keywords in _domain_config.get_domain_keywords().items():
+    for dom, keywords in _domain_helper.get_domain_keywords().items():
         for kw in keywords:
             if kw in fname:
                 if debug:
@@ -158,7 +158,7 @@ def get_domain_for_file(file_path, text=None, debug=False):
                 return assigned_domain
     if text:
         text_lower = text.lower()
-        for dom, keywords in _domain_config.get_domain_keywords().items():
+        for dom, keywords in _domain_helper.get_domain_keywords().items():
             for kw in keywords:
                 if kw in text_lower:
                     if debug:

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/domain_utils.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/utils/domain_utils.py
@@ -36,7 +36,7 @@ DOMAIN_KEYWORDS = {
     # Add more as needed
 }
 
-class DomainConfig:
+class DomainKeywordHelper:
     """Configuration wrapper for domain settings with fallback mechanisms."""
     
     def __init__(self, config_path: Optional[Union[str, ProjectConfig]] = None):
@@ -95,12 +95,12 @@ class DomainConfig:
         return self.keywords
 
 # Initialize default config
-_domain_config = DomainConfig()
+_domain_helper = DomainKeywordHelper()
 
 # Keep existing functions as wrappers for backward compatibility
 def get_valid_domains():
     """Get list of valid domains (backward compatible)."""
-    return _domain_config.get_valid_domains()
+    return _domain_helper.get_valid_domains()
 
 def get_domain_for_file(file_path, text=None, debug=False):
     """
@@ -164,7 +164,7 @@ def get_domain_for_file(file_path, text=None, debug=False):
                 return assigned_domain
     # 4. Keyword matching (filename/text)
     fname = os.path.basename(file_path_str).lower()
-    for dom, keywords in _domain_config.get_domain_keywords().items():
+    for dom, keywords in _domain_helper.get_domain_keywords().items():
         for kw in keywords:
             if kw in fname:
                 if debug:
@@ -176,7 +176,7 @@ def get_domain_for_file(file_path, text=None, debug=False):
                 return assigned_domain
     if text:
         text_lower = text.lower()
-        for dom, keywords in _domain_config.get_domain_keywords().items():
+        for dom, keywords in _domain_helper.get_domain_keywords().items():
             for kw in keywords:
                 if kw in text_lower:
                     if debug:

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_domain_config_wrapper.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_domain_config_wrapper.py
@@ -1,6 +1,6 @@
 """
 Test suite for domain configuration wrapper.
-Tests both the DomainConfig class and backward compatibility functions.
+Tests both the DomainKeywordHelper class and backward compatibility functions.
 """
 
 import os
@@ -13,7 +13,7 @@ project_root = str(Path(__file__).parent.parent)
 sys.path.append(project_root)
 
 from CryptoFinanceCorpusBuilder.utils.domain_utils import (
-    DomainConfig,
+    DomainKeywordHelper,
     get_valid_domains,
     get_domain_for_file
 )
@@ -46,7 +46,7 @@ class TestDomainConfigWrapper(unittest.TestCase):
 
     def test_default_config(self):
         """Test default configuration loading."""
-        config = DomainConfig()
+        config = DomainKeywordHelper()
         domains = config.get_valid_domains()
         self.assertIsInstance(domains, list)
         self.assertTrue(len(domains) > 0)
@@ -71,7 +71,7 @@ class TestDomainConfigWrapper(unittest.TestCase):
 
     def test_domain_keywords(self):
         """Test domain keyword functionality."""
-        config = DomainConfig()
+        config = DomainKeywordHelper()
         keywords = config.get_domain_keywords()
         self.assertIsInstance(keywords, dict)
         self.assertTrue(len(keywords) > 0)

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/utils/domain_utils.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/utils/domain_utils.py
@@ -31,7 +31,7 @@ DOMAIN_KEYWORDS = {
     # Add more as needed
 }
 
-class DomainConfig:
+class DomainKeywordHelper:
     """Configuration wrapper for domain settings with fallback mechanisms."""
     
     def __init__(self, config_path: Optional[str] = None):
@@ -76,12 +76,12 @@ class DomainConfig:
         return self.keywords
 
 # Initialize default config
-_domain_config = DomainConfig()
+_domain_helper = DomainKeywordHelper()
 
 # Keep existing functions as wrappers for backward compatibility
 def get_valid_domains():
     """Get list of valid domains (backward compatible)."""
-    return _domain_config.get_valid_domains()
+    return _domain_helper.get_valid_domains()
 
 def get_domain_for_file(file_path, text=None, debug=False):
     """
@@ -145,7 +145,7 @@ def get_domain_for_file(file_path, text=None, debug=False):
                 return assigned_domain
     # 4. Keyword matching (filename/text)
     fname = os.path.basename(file_path_str).lower()
-    for dom, keywords in _domain_config.get_domain_keywords().items():
+    for dom, keywords in _domain_helper.get_domain_keywords().items():
         for kw in keywords:
             if kw in fname:
                 if debug:
@@ -157,7 +157,7 @@ def get_domain_for_file(file_path, text=None, debug=False):
                 return assigned_domain
     if text:
         text_lower = text.lower()
-        for dom, keywords in _domain_config.get_domain_keywords().items():
+        for dom, keywords in _domain_helper.get_domain_keywords().items():
             for kw in keywords:
                 if kw in text_lower:
                     if debug:

--- a/CorpusBuilderApp/shared_tools/utils/domain_utils.py
+++ b/CorpusBuilderApp/shared_tools/utils/domain_utils.py
@@ -36,7 +36,7 @@ DOMAIN_KEYWORDS = {
     # Add more as needed
 }
 
-class DomainConfig:
+class DomainKeywordHelper:
     """Configuration wrapper for domain settings with fallback mechanisms."""
     
     def __init__(self, config_path: Optional[Union[str, Any]] = None):
@@ -95,12 +95,12 @@ class DomainConfig:
         return self.keywords
 
 # Initialize default config
-_domain_config = DomainConfig()
+_domain_helper = DomainKeywordHelper()
 
 # Keep existing functions as wrappers for backward compatibility
 def get_valid_domains():
     """Get list of valid domains (backward compatible)."""
-    return _domain_config.get_valid_domains()
+    return _domain_helper.get_valid_domains()
 
 def get_domain_for_file(file_path, text=None, debug=False):
     """
@@ -164,7 +164,7 @@ def get_domain_for_file(file_path, text=None, debug=False):
                 return assigned_domain
     # 4. Keyword matching (filename/text)
     fname = os.path.basename(file_path_str).lower()
-    for dom, keywords in _domain_config.get_domain_keywords().items():
+    for dom, keywords in _domain_helper.get_domain_keywords().items():
         for kw in keywords:
             if kw in fname:
                 if debug:
@@ -176,7 +176,7 @@ def get_domain_for_file(file_path, text=None, debug=False):
                 return assigned_domain
     if text:
         text_lower = text.lower()
-        for dom, keywords in _domain_config.get_domain_keywords().items():
+        for dom, keywords in _domain_helper.get_domain_keywords().items():
             for kw in keywords:
                 if kw in text_lower:
                     if debug:


### PR DESCRIPTION
## Summary
- rename helper class `DomainConfig` -> `DomainKeywordHelper`
- update all imports, variables and tests to new name

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests` *(fails: No module named 'yaml', ImportError: cannot import name 'entropy' from 'scipy.stats')*

------
https://chatgpt.com/codex/tasks/task_e_68442f61d5b88326bec8af2e753ec827