### PR TITLE
fix: finalize DomainKeywordHelper migration and remove leftover DomainConfig references

### DIFF
--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/balancer integration guide and examples.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/deprecated/balancer integration guide and examples.md
@@ -826,9 +826,9 @@ Here’s a log entry you can use to document the **Config Sync Phase** progress.
 - Created and used a test corpus with both PDF and non-PDF files.
 - Ran extractors to generate metadata and normalized outputs.
 
-#### **2. Domain Config Wrapper**
-- Implemented a `DomainConfig` wrapper in `domain_utils.py` for robust, backward-compatible config loading.
-- Ensured all extractors use the wrapper for domain info.
+#### **2. Domain Keyword Helper**
+- Implemented a `DomainKeywordHelper` utility in `domain_utils.py` for robust, backward-compatible config loading.
+- Ensured all extractors use the helper for domain info.
 
 #### **3. Balancer Test**
 - Ran the corpus balancer on both PDF and non-PDF test corpora.
@@ -867,7 +867,7 @@ Here’s a log entry you can use to document the **Config Sync Phase** progress.
 - `utils/config_validator.py` — New config validation script.
 - `cli/crypto_corpus_cli.py` — Added `validate-config` CLI command.
 - `config/balancer_config.py` — Updated domain weights to match project targets.
-- `utils/domain_utils.py` — Added/updated `DomainConfig` wrapper.
+- `utils/domain_utils.py` — Added/updated `DomainKeywordHelper` utility.
 - `config/domain_config.py` — (No changes needed; already matched intended allocations.)
 
 ---
@@ -1001,7 +1001,7 @@ Here is a **comprehensive, triple-checked list** of all files that need their im
   - `from CryptoFinanceCorpusBuilder.utils.extractor_utils import ...` → `from shared_tools.utils.extractor_utils import ...`
 - `test_quality_control_config.py`
   - `from CryptoFinanceCorpusBuilder.utils.extractor_utils import ...` → `from shared_tools.utils.extractor_utils import ...`
-- `test_domain_config_wrapper.py`
+ - `test_domain_keyword_helper.py`
   - `from CryptoFinanceCorpusBuilder.utils.domain_utils import ...` → `from shared_tools.utils.domain_utils import ...`
 
 ---

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_domain_keyword_helper.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/tests/deprecated/test_domain_keyword_helper.py
@@ -19,7 +19,7 @@ from CryptoFinanceCorpusBuilder.utils.domain_utils import (
     get_domain_for_file
 )
 
-class TestDomainConfigWrapper(unittest.TestCase):
+class TestDomainKeywordHelper(unittest.TestCase):
     def setUp(self):
         """Set up test environment."""
         self.test_corpus_dir = Path(project_root) / "data" / "test_corpus_sample"

--- a/CorpusBuilderApp/docs/test_guide.md
+++ b/CorpusBuilderApp/docs/test_guide.md
@@ -29,7 +29,7 @@ The table below lists all test modules and the directories or inputs they expect
 | corpusbuilder/tests/deprecated/test_arxiv_collector_projectconfig.py | config/master_config.yaml | Arxiv collector with ProjectConfig |
 | corpusbuilder/tests/deprecated/test_bitmex_collector.py | mock_bitmex_research.html file | Parses BitMEX research posts |
 | corpusbuilder/tests/deprecated/test_chunking_behavior.py | data/test_collect/chunking_tests/* | Chunking of CSV/py/ipynb/JSON files |
-| corpusbuilder/tests/deprecated/test_domain_config_wrapper.py | None | Domain config wrapper logic |
+| corpusbuilder/tests/deprecated/test_domain_keyword_helper.py | None | Domain keyword helper logic |
 | corpusbuilder/tests/deprecated/test_fred_collector.py | FRED_API_KEY env var, config/test_config.yaml | Downloads data from FRED |
 | corpusbuilder/tests/deprecated/test_general_web_collector.py | None | Web scraping collector |
 | corpusbuilder/tests/deprecated/test_github_collector.py | GitHub token env var, output dir | Clones GitHub repos |


### PR DESCRIPTION
## Summary
- rename deprecated domain-config test to domain-keyword helper
- update docs to mention DomainKeywordHelper and new test name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_6844317ff9d08326b853790d91b611f7