### PR TITLE
Fix processor wrapper initialization

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/processors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/processors_tab.py
@@ -433,15 +433,15 @@ class ProcessorsTab(QWidget):
             # Wrappers that expect config_path (string)
 
             path_wrappers = [
+            ]
+
+            # Wrappers that expect config object
+            object_wrappers = [
                 ('pdf', PDFExtractorWrapper),
                 ('text', TextExtractorWrapper),
                 ('domain', DomainClassifierWrapper),
                 ('formula', FormulaExtractorWrapper),
-                ('chart', ChartImageExtractorWrapper)
-            ]
-            
-            # Wrappers that expect config object
-            object_wrappers = [
+                ('chart', ChartImageExtractorWrapper),
                 ('quality', QualityControlWrapper),
                 ('language', LanguageConfidenceDetectorWrapper),
                 ('mt_detector', MachineTranslationDetectorWrapper),


### PR DESCRIPTION
## Summary
- ensure ProcessorsTab uses ProjectConfig for all processor wrappers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*


------
https://chatgpt.com/codex/tasks/task_e_68443237c0b88326bb315e379f419a8a