### PR TITLE
Fix ProjectConfig import paths

### DIFF
--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/collect_annas_main_library.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/collectors/collect_annas_main_library.py
@@ -39,7 +39,7 @@ except ImportError:
 
 # Import ProjectConfig if available
 try:
-    from shared_tools.config.project_config import ProjectConfig  # type: ignore
+    from shared_tools.project_config import ProjectConfig  # type: ignore
     logger.info("Successfully imported ProjectConfig")
 except ImportError:
     logger.warning("ProjectConfig not found. Legacy mode will be used if --project-config is not provided.")
@@ -63,7 +63,7 @@ def safe_filename(s):
 class AnnasMainLibraryCollector(BaseCollector):
     def __init__(self, config, account_cookie=None):
         if isinstance(config, str):
-            from shared_tools.config.project_config import ProjectConfig
+            from shared_tools.project_config import ProjectConfig
             config = ProjectConfig(config, environment='test')
         super().__init__(config)
 

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/collect_annas_main_library.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/prev_working/previously working collectors/collect_annas_main_library.py
@@ -38,7 +38,7 @@ except ImportError:
 
 # Import ProjectConfig if available
 try:
-    from shared_tools.config.project_config import ProjectConfig  # type: ignore
+    from shared_tools.project_config import ProjectConfig  # type: ignore
     logger.info("Successfully imported ProjectConfig")
 except ImportError:
     logger.warning("ProjectConfig not found. Legacy mode will be used if --project-config is not provided.")

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/chart_image_extractor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/chart_image_extractor.py
@@ -683,7 +683,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from shared_tools.config.project_config import ProjectConfig
+        from shared_tools.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/finacial_symbol_processor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/finacial_symbol_processor.py
@@ -792,7 +792,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from shared_tools.config.project_config import ProjectConfig
+        from shared_tools.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/formula_extractor.py
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/shared_tools/processors/formula_extractor.py
@@ -478,7 +478,7 @@ def main():
     
     if args.project_config:
         # Use project config
-        from shared_tools.config.project_config import ProjectConfig
+        from shared_tools.project_config import ProjectConfig
         project = ProjectConfig.load(args.project_config)
         results = run_with_project_config(project, args.verbose)
     else:

--- a/CorpusBuilderApp/shared_tools/collectors/collect_annas_main_library.py
+++ b/CorpusBuilderApp/shared_tools/collectors/collect_annas_main_library.py
@@ -42,7 +42,7 @@ except ImportError:
 
 # Import ProjectConfig if available
 try:
-    from shared_tools.config.project_config import ProjectConfig  # type: ignore
+    from shared_tools.project_config import ProjectConfig  # type: ignore
     logger.info("Successfully imported ProjectConfig")
 except ImportError:
     logger.warning("ProjectConfig not found. Legacy mode will be used if --project-config is not provided.")
@@ -62,7 +62,7 @@ def load_existing_titles(existing_titles_path):
 class AnnasMainLibraryCollector(BaseCollector):
     def __init__(self, config, account_cookie=None):
         if isinstance(config, str):
-            from shared_tools.config.project_config import ProjectConfig
+            from shared_tools.project_config import ProjectConfig
             config = ProjectConfig(config, environment='test')
         super().__init__(config)
 


### PR DESCRIPTION
## Summary
- update ProjectConfig imports to use `shared_tools.project_config`
- fix all remaining references across collectors and processors

## Testing
- `grep -R "shared_tools.config.project_config" -n` (no results)
- `pytest -q` *(fails: ModuleNotFoundError for fitz, dotenv, requests)*

------
https://chatgpt.com/codex/tasks/task_e_684438c660c08326a7a8183fe62207d2