### PR TITLE
Fix import path in June README

### DIFF
--- a/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/README_JUNE.md
+++ b/CorpusBuilderApp/CryptoFinanceCorpusBuilder/readmes/README_JUNE.md
@@ -333,7 +333,7 @@ Located in: `corpusbuilder/shared_tools/storage/`
 2. **Run Collection**:
    ```python
    from CryptoFinanceCorpusBuilder.shared_tools.collectors import SciDBCollector
-   from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+   from shared_tools.project_config import ProjectConfig
    import json
 
    # Load configuration


### PR DESCRIPTION
## Summary
- fix package path for `ProjectConfig` example in README_JUNE.md

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_684438cc244083269aa466fe713af271