### PR TITLE
Update docs to note prev_working deprecation

### DIFF
--- a/CorpusBuilderApp/docs/deprecated/final-summary.md
+++ b/CorpusBuilderApp/docs/deprecated/final-summary.md
@@ -27,10 +27,10 @@ Each collector has been wrapped with a UI-compatible interface providing start()
 
 ### 3. Stable Processor Integration
 
-The most stable, feature-complete versions of all processors have been integrated:
-- PDF Extractor (from prev_working)
-- Text Extractor (from prev_working)
-- Corpus Balancer (from prev_working)
+Processors located in the `prev_working` directory are **deprecated** and scheduled for removal:
+- PDF Extractor
+- Text Extractor
+- Corpus Balancer
 
 All processors have been wrapped with thread-safe interfaces that support batch processing, error handling, and progress reporting.
 

--- a/CorpusBuilderApp/setup-and-docs.md
+++ b/CorpusBuilderApp/setup-and-docs.md
@@ -376,7 +376,7 @@ corpusbuilder/
 ├── shared_tools/                 # Core functionality
 │   ├── collectors/               # Data collectors
 │   ├── processors/               # Data processors
-│   ├── prev_working/             # Stable processor versions
+│   ├── prev_working/             # Deprecated processor versions (scheduled for removal)
 │   ├── ui_wrappers/              # UI integration wrappers
 │   │   ├── base_wrapper.py
 │   │   ├── collectors/           # Collector wrappers


### PR DESCRIPTION
## Summary
- document that `shared_tools/prev_working` is deprecated
- clarify in deprecated summary that processors from `prev_working` are being removed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_684438f0a46c8326bf7414ae2bfba7d3