### PR TITLE
Update prev_working cleanup issue

### DIFF
--- a/.github/issues/cleanup_prev_working_modules.md
+++ b/.github/issues/cleanup_prev_working_modules.md
@@ -1,6 +1,9 @@
 # \U0001F9F9 Cleanup: Remove deprecated prev_working/ modules
 
-- [ ] Confirm no runtime imports rely on `prev_working` modules
+- [x] Confirm no runtime imports rely on `prev_working` modules
 - [ ] Remove `prev_working` directories
 - [ ] Run tests to ensure no regressions
+
+Deletion of `shared_tools/prev_working` and all subdirectories will occur once
+related documentation and configuration files are updated.
 


### PR DESCRIPTION
## Summary
- mark that there are no imports from `prev_working`
- note planned deletion of the `prev_working` directory after docs and configs are updated

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fitz and dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_684438f311b083269ab4c732383c65e2