### PR TITLE
Fix hardcoded paths in processors

### DIFF
--- a/CorpusBuilderApp/shared_tools/processors/batch_nonpdf_extractor_enhanced.py
+++ b/CorpusBuilderApp/shared_tools/processors/batch_nonpdf_extractor_enhanced.py
@@ -5,6 +5,7 @@ import json
 import ast
 import re
 import os
+import tempfile
 from datetime import datetime, timezone
 import concurrent.futures
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -39,8 +40,13 @@ from ..utils.domain_utils import get_domain_for_file, DOMAIN_KEYWORDS
 from ..utils.metadata_normalizer import main as normalize_directory
 from shared_tools.project_config import ProjectConfig
 
-# Configure logging
-log_dir = Path("G:/ai_trading_dev/CryptoFinanceCorpusBuilder/logs")
+# Load project configuration for default paths.  A custom path can be provided
+# via the ``PROJECT_CONFIG`` environment variable.
+_DEFAULT_CONFIG = Path(__file__).resolve().parents[2] / "configs" / "quick_test.yaml"
+_PROJECT = ProjectConfig(os.environ.get("PROJECT_CONFIG", str(_DEFAULT_CONFIG)))
+
+# Configure logging using the project configuration
+log_dir = _PROJECT.get_logs_dir()
 log_dir.mkdir(parents=True, exist_ok=True)
 log_file = log_dir / "batch_nonpdf_extractor.log"
 logging.basicConfig(
@@ -96,7 +102,8 @@ print('DEBUG: sys.path =', sys.path)
 def get_worker_temp_dir():
     """Get temporary directory for current worker"""
     worker_id = getattr(thread_local, 'worker_id', 'unknown')
-    base_temp = Path("G:/ai_trading_dev/CryptoFinanceCorpusBuilder/temp_workers")
+    env_temp = _PROJECT.get('environment.temp_dir', tempfile.gettempdir())
+    base_temp = Path(env_temp) / 'temp_workers'
     base_temp.mkdir(parents=True, exist_ok=True)
     temp_dir = base_temp / f"temp_worker_{worker_id}"
     temp_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- load ProjectConfig at module import time
- pull log/temp paths from ProjectConfig in batch processors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_684438f26d6483268fb814447b2c9bd2