### PR TITLE
Add dark theme stat card styling

### DIFF
--- a/CorpusBuilderApp/app/resources/styles/theme_dark.qss
+++ b/CorpusBuilderApp/app/resources/styles/theme_dark.qss
@@ -678,6 +678,12 @@ QLabel, QChartLegend, QChartView {
 }
 
 /* === STAT CARDS === */
+QFrame[objectName="stat-card"] {
+    background-color: #262828;
+    border: 1px solid #232525;
+    border-radius: 12px;
+    padding: 16px;
+}
 QWidget[objectName="stat-card"] QLabel[objectName="stat-value"] {
     font-size: 32px;
     font-weight: 700;


### PR DESCRIPTION
## Summary
- add stat-card block to `theme_dark.qss`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for various packages)*

------
https://chatgpt.com/codex/tasks/task_e_68443dadf9008326b1f1104cce365de5