### PR TITLE
Update dark QSS theme

### DIFF
--- a/CorpusBuilderApp/app/resources/styles/theme_dark.qss
+++ b/CorpusBuilderApp/app/resources/styles/theme_dark.qss
@@ -732,3 +732,7 @@ QLabel[objectName^="status-dot-"] {
 QLabel[objectName="status-dot-active"] { background: #10b981; }
 QLabel[objectName="status-dot-processing"] { background: #06b6d4; }
 QLabel[objectName="status-dot-idle"] { background: #6b7280; }
+QLabel[objectName="status-dot-success"]  { background: #10b981; }
+QLabel[objectName="status-dot-error"]    { background: #ef4444; }
+QLabel[objectName="status-dot-warning"]  { background: #f59e0b; }
+QLabel[objectName="status-dot-info"]     { background: #06b6d4; }


### PR DESCRIPTION
## Summary
- update dark theme QSS with shared status dot styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68443db0c0bc8326b187dc62d2194f6b