### PR TITLE
Update dashboard layout to grid

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
@@ -5,6 +5,7 @@ from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QHBoxLayout,
+    QGridLayout,
     QFrame,
     QLabel,
     QPushButton,
@@ -38,23 +39,27 @@ class DashboardTab(QWidget):
         main_layout.setContentsMargins(16, 16, 16, 16)
         main_layout.setSpacing(16)
 
-        # Top statistics row
-        stats_layout = QHBoxLayout()
+        # Top statistics grid
+        stats_layout = QGridLayout()
         stats_layout.setSpacing(16)
 
         self.collectors_card = self._create_stat_card(
             "Active Collectors", str(self.active_collectors)
         )
-        stats_layout.addWidget(self.collectors_card)
+        stats_layout.addWidget(self.collectors_card, 0, 0)
 
         self.processors_card = self._create_stat_card(
             "Active Processors", str(self.active_processors)
         )
-        stats_layout.addWidget(self.processors_card)
+        stats_layout.addWidget(self.processors_card, 0, 1)
 
         self.errors_card = self._create_stat_card("Errors", str(self.error_count))
-        stats_layout.addWidget(self.errors_card)
-        stats_layout.addStretch()
+        stats_layout.addWidget(self.errors_card, 1, 0)
+
+        self.documents_card = self._create_stat_card(
+            "Total Documents", str(self.total_documents)
+        )
+        stats_layout.addWidget(self.documents_card, 1, 1)
 
         main_layout.addLayout(stats_layout)
 
@@ -146,6 +151,9 @@ class DashboardTab(QWidget):
             self.total_docs_label.setText(
                 f"Total Documents: {self.total_documents}"
             )
+            value_label = self.documents_card.findChild(QLabel, "stat-value")
+            if value_label:
+                value_label.setText(str(self.total_documents))
 
             distribution = (
                 stats.get("domain_metrics", {}).get("domain_distribution")

--- a/CorpusBuilderApp/tests/ui/test_dashboard_tab.py
+++ b/CorpusBuilderApp/tests/ui/test_dashboard_tab.py
@@ -14,7 +14,7 @@ def dashboard_tab(qapp, mock_project_config, qtbot):
 
 def test_stat_cards_exist(dashboard_tab):
     cards = dashboard_tab.findChildren(QFrame, "stat-card")
-    assert len(cards) == 3
+    assert len(cards) == 4
 
 
 def test_view_all_activity_signal(dashboard_tab, qtbot):


### PR DESCRIPTION
## Summary
- switch dashboard stat layout from horizontal box to grid
- show total document count in a fourth stat card
- expect four stat cards in dashboard UI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844415c6704832695d5ba308f73f4b6