### PR TITLE
Improve logs tab layout

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/logs_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/logs_tab.py
@@ -42,7 +42,11 @@ class LogsTab(QWidget):
         main_layout.addWidget(header)
 
         # Log navigation and filtering controls
+        controls_card = CardWrapper()
         controls_layout = QHBoxLayout()
+        controls_layout.setContentsMargins(0, 0, 0, 0)
+        controls_layout.setSpacing(8)
+        controls_card.body_layout.addLayout(controls_layout)
         
         # Log selector
         controls_layout.addWidget(QLabel("Log:"))
@@ -70,7 +74,7 @@ class LogsTab(QWidget):
         self.today_only.stateChanged.connect(self.apply_filters)
         controls_layout.addWidget(self.today_only)
         
-        main_layout.addLayout(controls_layout)
+        main_layout.addWidget(controls_card)
         
         # Create a splitter for log table and details
         splitter = QSplitter(Qt.Orientation.Vertical)


### PR DESCRIPTION
## Summary
- wrap filter controls in a `CardWrapper`
- keep controls in a horizontal row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684441c4ab9c8326af4ca301516e9ae8