### PR TITLE
Add worker thread control to extractor wrappers

### DIFF
--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/pdf_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/pdf_extractor_wrapper.py
@@ -75,6 +75,7 @@ class PDFExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
         self.enable_ocr = True
         self.extract_tables = True
         self.extract_formulas = True
+        self.worker_threads = 4
         
     def _create_target_object(self):
         """Create PDF extractor instance"""
@@ -82,7 +83,7 @@ class PDFExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
             self.extractor = PDFExtractor(
                 input_dir=str(self.config.raw_data_dir),
                 output_dir=str(self.config.pdf_extracted_dir),
-                num_workers=4
+                num_workers=self.worker_threads
             )
         return self.extractor
         
@@ -100,6 +101,12 @@ class PDFExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
     def set_formula_extraction(self, enabled):
         """Set formula extraction enabled/disabled"""
         self.extract_formulas = enabled
+
+    def set_worker_threads(self, count: int):
+        """Set the number of worker threads for processing"""
+        self.worker_threads = count
+        if self.extractor:
+            self.extractor.num_workers = count
         
     def start_batch_processing(self, files_to_process: List[str]):
         """Start batch processing of PDF files"""

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/text_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/text_extractor_wrapper.py
@@ -76,6 +76,7 @@ class TextExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
     def __init__(self, config):
         super().__init__(config)
         self.extractor = None
+        self.worker_threads = 4
         
     def _create_target_object(self):
         """Create Text extractor instance"""
@@ -83,12 +84,18 @@ class TextExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
             self.extractor = TextExtractor(
                 input_dir=str(self.config.raw_data_dir),
                 output_dir=str(self.config.nonpdf_extracted_dir),
-                num_workers=4
+                num_workers=self.worker_threads
             )
         return self.extractor
         
     def _get_operation_type(self):
         return "extract_text"
+
+    def set_worker_threads(self, count: int):
+        """Set the number of worker threads for processing"""
+        self.worker_threads = count
+        if self.extractor:
+            self.extractor.num_workers = count
         
     def start_batch_processing(self, files_to_process: List[str]):
         """Start batch processing of non-PDF files"""

--- a/tests/wrappers/test_worker_threads.py
+++ b/tests/wrappers/test_worker_threads.py
@@ -1,0 +1,77 @@
+import types
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+
+# Add project paths for imports
+root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(root))
+sys.path.insert(1, str(root / "CorpusBuilderApp"))
+
+# Stub heavy third-party dependencies
+dummy = types.ModuleType("dummy")
+sys.modules.setdefault("PyPDF2", dummy)
+sys.modules.setdefault("fitz", dummy)
+pdfminer_high = types.ModuleType("pdfminer.high_level")
+pdfminer_high.extract_text = lambda *a, **k: ""
+pdfminer_high.extract_pages = lambda *a, **k: []
+sys.modules.setdefault("pdfminer.high_level", pdfminer_high)
+pdfminer_layout = types.ModuleType("pdfminer.layout")
+pdfminer_layout.LTTextContainer = object
+pdfminer_layout.LTChar = object
+pdfminer_layout.LTFigure = object
+sys.modules.setdefault("pdfminer.layout", pdfminer_layout)
+
+# Provide dummy extractor modules to avoid heavy dependencies
+dummy_pdf_extractor_mod = types.ModuleType("shared_tools.processors.pdf_extractor")
+class DummyPDFExtractor:
+    def __init__(self, *a, **k):
+        self.num_workers = k.get("num_workers")
+dummy_pdf_extractor_mod.PDFExtractor = DummyPDFExtractor
+sys.modules.setdefault("shared_tools.processors.pdf_extractor", dummy_pdf_extractor_mod)
+
+dummy_text_extractor_mod = types.ModuleType("shared_tools.processors.text_extractor")
+class DummyTextExtractor:
+    def __init__(self, *a, **k):
+        self.num_workers = k.get("num_workers")
+dummy_text_extractor_mod.TextExtractor = DummyTextExtractor
+sys.modules.setdefault("shared_tools.processors.text_extractor", dummy_text_extractor_mod)
+
+qtcore = types.SimpleNamespace(
+    QObject=object,
+    Signal=lambda *a, **k: lambda *a, **k: None,
+    QThread=object,
+    QTimer=object,
+)
+sys.modules.setdefault("PySide6", types.SimpleNamespace(QtCore=qtcore))
+sys.modules.setdefault("PySide6.QtCore", qtcore)
+
+from shared_tools.ui_wrappers.processors.pdf_extractor_wrapper import PDFExtractorWrapper
+from shared_tools.ui_wrappers.processors.text_extractor_wrapper import TextExtractorWrapper
+
+
+def test_pdf_worker_threads(tmp_path):
+    cfg = SimpleNamespace(
+        raw_data_dir=tmp_path / "raw",
+        pdf_extracted_dir=tmp_path / "pdf",
+    )
+    wrapper = PDFExtractorWrapper(cfg)
+    wrapper.set_worker_threads(6)
+    extractor = wrapper._create_target_object()
+    assert extractor.num_workers == 6
+    wrapper.set_worker_threads(2)
+    assert extractor.num_workers == 2
+
+
+def test_text_worker_threads(tmp_path):
+    cfg = SimpleNamespace(
+        raw_data_dir=tmp_path / "raw",
+        nonpdf_extracted_dir=tmp_path / "text",
+    )
+    wrapper = TextExtractorWrapper(cfg)
+    wrapper.set_worker_threads(8)
+    extractor = wrapper._create_target_object()
+    assert extractor.num_workers == 8
+    wrapper.set_worker_threads(3)
+    assert extractor.num_workers == 3


### PR DESCRIPTION
## Summary
- allow configuring worker threads for PDF and text extractors
- cover new behaviour with unit tests using dummy dependencies

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/wrappers/test_worker_threads.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68471033795c83269ccd827e5867942a