### PR TITLE
Implement enable toggles for processor wrappers

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/processors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/processors_tab.py
@@ -613,21 +613,18 @@ class ProcessorsTab(QWidget):
     
     def apply_advanced_processing(self):
         # Enable/disable processors based on UI selections
-        self.processor_wrappers['deduplicator'].set_enabled(
-            self.enable_deduplication.isChecked()
-        )
-        self.processor_wrappers['domain'].set_enabled(
-            self.enable_domain_classification.isChecked()
-        )
-        self.processor_wrappers['financial'].set_enabled(
-            self.enable_financial_symbols.isChecked()
-        )
-        self.processor_wrappers['language'].set_enabled(
-            self.enable_language_confidence.isChecked()
-        )
-        self.processor_wrappers['mt_detector'].set_enabled(
-            self.enable_mt_detection.isChecked()
-        )
+        wrapper_map = {
+            'deduplicator': self.enable_deduplication.isChecked(),
+            'domain': self.enable_domain_classification.isChecked(),
+            'financial': self.enable_financial_symbols.isChecked(),
+            'language': self.enable_language_confidence.isChecked(),
+            'mt_detector': self.enable_mt_detection.isChecked(),
+        }
+
+        for key, flag in wrapper_map.items():
+            wrapper = self.processor_wrappers.get(key)
+            if wrapper and hasattr(wrapper, 'set_enabled'):
+                wrapper.set_enabled(flag)
         
         # Start a complex batch operation that applies multiple processors
         self.advanced_status.setText("Starting advanced processing...")

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/deduplicator_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/deduplicator_wrapper.py
@@ -18,9 +18,17 @@ class DeduplicatorWrapper(BaseWrapper, ProcessorWrapperMixin):
         self._is_running = False
         self.worker_thread = None
         self.similarity_threshold = 0.85  # Default threshold
+        self._enabled = True
+
+    def set_enabled(self, enabled: bool):
+        """Enable or disable the wrapper."""
+        self._enabled = bool(enabled)
         
     def start(self, file_paths=None, **kwargs):
         """Start deduplication processing on the specified files."""
+        if not self._enabled:
+            self.status_updated.emit("Deduplicator disabled")
+            return False
         if self._is_running:
             self.status_updated.emit("Deduplication already in progress")
             return False

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domain_classifier_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domain_classifier_wrapper.py
@@ -15,9 +15,17 @@ class DomainClassifierWrapper(BaseWrapper, ProcessorWrapperMixin):
         self.processor = DomainClassifier(project_config)
         self._is_running = False
         self.worker_thread = None
+        self._enabled = True
+
+    def set_enabled(self, enabled: bool):
+        """Enable or disable the wrapper."""
+        self._enabled = bool(enabled)
         
     def start(self, documents=None, **kwargs):
         """Start domain classification on the specified documents."""
+        if not self._enabled:
+            self.status_updated.emit("Domain classifier disabled")
+            return False
         if self._is_running:
             self.status_updated.emit("Domain classification already in progress")
             return False

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/financial_symbol_processor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/financial_symbol_processor_wrapper.py
@@ -15,9 +15,17 @@ class FinancialSymbolProcessorWrapper(BaseWrapper, ProcessorWrapperMixin):
         self.processor = FinancialSymbolProcessor(project_config)
         self._is_running = False
         self.worker_thread = None
+        self._enabled = True
+
+    def set_enabled(self, enabled: bool):
+        """Enable or disable the wrapper."""
+        self._enabled = bool(enabled)
         
     def start(self, file_paths=None, **kwargs):
         """Start financial symbol extraction on the specified files."""
+        if not self._enabled:
+            self.status_updated.emit("Financial symbol processor disabled")
+            return False
         if self._is_running:
             self.status_updated.emit("Financial symbol extraction already in progress")
             return False

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/language_confidence_detector_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/language_confidence_detector_wrapper.py
@@ -15,9 +15,17 @@ class LanguageConfidenceDetectorWrapper(BaseWrapper, ProcessorWrapperMixin):
         self.processor = LanguageConfidenceDetector(project_config)
         self._is_running = False
         self.worker_thread = None
+        self._enabled = True
+
+    def set_enabled(self, enabled: bool):
+        """Enable or disable the wrapper."""
+        self._enabled = bool(enabled)
         
     def start(self, file_paths=None, **kwargs):
         """Start language detection on the specified files."""
+        if not self._enabled:
+            self.status_updated.emit("Language confidence detector disabled")
+            return False
         if self._is_running:
             self.status_updated.emit("Language detection already in progress")
             return False

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/machine_translation_detector_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/machine_translation_detector_wrapper.py
@@ -15,9 +15,17 @@ class MachineTranslationDetectorWrapper(BaseWrapper, ProcessorWrapperMixin):
         self.processor = MachineTranslationDetector(project_config)
         self._is_running = False
         self.worker_thread = None
+        self._enabled = True
+
+    def set_enabled(self, enabled: bool):
+        """Enable or disable the wrapper."""
+        self._enabled = bool(enabled)
         
     def start(self, file_paths=None, **kwargs):
         """Start machine translation detection on the specified files."""
+        if not self._enabled:
+            self.status_updated.emit("Machine translation detector disabled")
+            return False
         if self._is_running:
             self.status_updated.emit("Machine translation detection already in progress")
             return False

--- a/CorpusBuilderApp/tests/unit/test_processor_enabled_flag.py
+++ b/CorpusBuilderApp/tests/unit/test_processor_enabled_flag.py
@@ -1,0 +1,106 @@
+import sys
+import types
+from unittest.mock import patch, MagicMock
+import pytest
+
+# Stub heavy dependencies
+class _DummySignal:
+    def emit(self, *a, **k):
+        pass
+
+qtcore = types.SimpleNamespace(
+    QObject=object,
+    Signal=lambda *a, **k: _DummySignal(),
+    QThread=object,
+    QTimer=object,
+    Slot=lambda *a, **k: lambda *a, **k: None,
+    QDir=object,
+)
+qtwidgets = types.SimpleNamespace(QApplication=type('QApplication', (), {'instance': staticmethod(lambda: None)}))
+sys.modules.setdefault('PySide6', types.SimpleNamespace(QtCore=qtcore, QtWidgets=qtwidgets))
+sys.modules.setdefault('PySide6.QtCore', qtcore)
+sys.modules.setdefault('PySide6.QtWidgets', qtwidgets)
+for mod in ['fitz','pytesseract','cv2','numpy','matplotlib','matplotlib.pyplot','seaborn']:
+    sys.modules.setdefault(mod, types.ModuleType(mod))
+# Stub PIL
+dummy_image_mod = types.ModuleType('PIL.Image')
+class DummyImage: ...
+dummy_image_mod.Image = DummyImage
+dummy_enhance_mod = types.ModuleType('PIL.ImageEnhance')
+class DummyEnhance: ...
+dummy_enhance_mod.ImageEnhance = DummyEnhance
+dummy_pil = types.ModuleType('PIL')
+dummy_pil.Image = dummy_image_mod
+dummy_pil.ImageEnhance = dummy_enhance_mod
+sys.modules.setdefault('PIL', dummy_pil)
+sys.modules.setdefault('PIL.Image', dummy_image_mod)
+sys.modules.setdefault('PIL.ImageEnhance', dummy_enhance_mod)
+if 'langdetect' not in sys.modules:
+    langdetect = types.ModuleType('langdetect')
+    langdetect.detect_langs = lambda *a, **k: []
+    langdetect.LangDetectException = Exception
+    sys.modules['langdetect'] = langdetect
+
+from shared_tools.ui_wrappers.processors.deduplicator_wrapper import DeduplicatorWrapper
+from shared_tools.ui_wrappers.processors.domain_classifier_wrapper import DomainClassifierWrapper
+from shared_tools.ui_wrappers.processors.financial_symbol_processor_wrapper import FinancialSymbolProcessorWrapper
+from shared_tools.ui_wrappers.processors.language_confidence_detector_wrapper import LanguageConfidenceDetectorWrapper
+from shared_tools.ui_wrappers.processors.machine_translation_detector_wrapper import MachineTranslationDetectorWrapper
+
+@pytest.mark.parametrize(
+    "wrapper_cls,worker_path,processor_path,start_args",
+    [
+        (
+            DeduplicatorWrapper,
+            "shared_tools.ui_wrappers.processors.deduplicator_wrapper.DeduplicatorWorkerThread",
+            "shared_tools.ui_wrappers.processors.deduplicator_wrapper.Deduplicator",
+            (["f1"],),
+        ),
+        (
+            DomainClassifierWrapper,
+            "shared_tools.ui_wrappers.processors.domain_classifier_wrapper.DomainClassifierWorkerThread",
+            "shared_tools.ui_wrappers.processors.domain_classifier_wrapper.DomainClassifier",
+            ({"doc": {"text": "t"}},),
+        ),
+        (
+            FinancialSymbolProcessorWrapper,
+            "shared_tools.ui_wrappers.processors.financial_symbol_processor_wrapper.FinancialSymbolWorkerThread",
+            "shared_tools.ui_wrappers.processors.financial_symbol_processor_wrapper.FinancialSymbolProcessor",
+            (["f1"],),
+        ),
+        (
+            LanguageConfidenceDetectorWrapper,
+            "shared_tools.ui_wrappers.processors.language_confidence_detector_wrapper.LanguageDetectorWorkerThread",
+            "shared_tools.ui_wrappers.processors.language_confidence_detector_wrapper.LanguageConfidenceDetector",
+            (["f1"],),
+        ),
+        (
+            MachineTranslationDetectorWrapper,
+            "shared_tools.ui_wrappers.processors.machine_translation_detector_wrapper.MTDetectorWorkerThread",
+            "shared_tools.ui_wrappers.processors.machine_translation_detector_wrapper.MachineTranslationDetector",
+            (["f1"],),
+        ),
+    ],
+)
+def test_start_respects_enabled_flag(mock_project_config, wrapper_cls, worker_path, processor_path, start_args):
+    with patch(processor_path):
+        wrapper = wrapper_cls(mock_project_config)
+    wrapper.processor = MagicMock()
+    for attr in ["_on_progress_updated", "_on_status_updated", "_on_error"]:
+        setattr(wrapper, attr, lambda *a, **k: None)
+
+    wrapper.set_enabled(False)
+    with patch(worker_path) as worker_cls:
+        result = wrapper.start(*start_args)
+        assert result is False
+        worker_cls.assert_not_called()
+        assert wrapper.is_running() is False
+
+    wrapper.set_enabled(True)
+    with patch(worker_path) as worker_cls:
+        worker = MagicMock()
+        worker_cls.return_value = worker
+        result = wrapper.start(*start_args)
+        assert result is True
+        worker.start.assert_called_once()
+        assert wrapper.is_running() is True


### PR DESCRIPTION
## Summary
- add `set_enabled` logic to processor wrappers
- guard apply_advanced_processing against missing wrappers
- stub PySide6 and heavy deps in tests
- test that wrappers obey enabled flag

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts='' tests/cli/test_execute_from_config.py CorpusBuilderApp/tests/unit/test_processor_enabled_flag.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684710348f488326a5a9dc06e594d2a1