### PR TITLE
Connect apply_to_selected_btn

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/processors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/processors_tab.py
@@ -306,6 +306,7 @@ class ProcessorsTab(QWidget):
         batch_layout.addWidget(self.apply_to_all_btn)
         
         self.apply_to_selected_btn = QPushButton("Apply to Selected Domain")
+        self.apply_to_selected_btn.clicked.connect(self.apply_selected_domain)
         batch_layout.addWidget(self.apply_to_selected_btn)
         
         layout.addWidget(batch_group)
@@ -640,6 +641,14 @@ class ProcessorsTab(QWidget):
         # This would be done with proper processing in the real implementation
         self.advanced_progress_bar.setValue(100)
         self.advanced_status.setText("Advanced processing completed")
+
+    @pyqtSlot()
+    def apply_selected_domain(self):
+        """Apply advanced processing to a user-selected domain."""
+        # Placeholder for more complex domain-specific logic
+        self.advanced_status.setText(
+            "Processing selected domain... (not yet implemented)"
+        )
 
     def start_batch_processing(self):
         input_dir = self.input_dir_path.text()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,109 @@
+import sys
+import types
+
+if 'PySide6' not in sys.modules:
+    class _Signal:
+        def __init__(self, *a, **k):
+            self._slots = []
+        def connect(self, slot):
+            self._slots.append(slot)
+        def emit(self, *a, **k):
+            for s in self._slots:
+                s(*a, **k)
+    class QApplication:
+        _instance = None
+        def __init__(self, *a, **k):
+            QApplication._instance = self
+        @classmethod
+        def instance(cls):
+            return cls._instance
+        def quit(self):
+            pass
+    class QDir:
+        @staticmethod
+        def homePath():
+            import os
+            return os.path.expanduser('~')
+        @staticmethod
+        def rootPath():
+            return '/'
+    class QPushButton:
+        def __init__(self, *a, **k):
+            self.clicked = _Signal()
+    class QLabel:
+        def __init__(self, *a, **k):
+            self._text = ''
+        def setText(self, t):
+            self._text = t
+        def text(self):
+            return self._text
+        def setObjectName(self, n):
+            pass
+    class QProgressBar:
+        def __init__(self, *a, **k):
+            self._value = 0
+        def setRange(self, a, b):
+            pass
+        def setValue(self, v):
+            self._value = v
+    class QCheckBox:
+        def __init__(self, *a, **k):
+            self._checked = False
+        def setChecked(self, v):
+            self._checked = v
+        def isChecked(self):
+            return self._checked
+    class QWidget: pass
+    class QVBoxLayout:
+        def __init__(self, *a, **k):
+            pass
+        def addWidget(self, *a, **k):
+            pass
+        def addLayout(self, *a, **k):
+            pass
+    class QGroupBox(QWidget):
+        def __init__(self, *a, **k):
+            pass
+    class QSpinBox:
+        def __init__(self, *a, **k):
+            self._value = 0
+        def setRange(self, a, b):
+            pass
+        def setValue(self, v):
+            self._value = v
+        def value(self):
+            return self._value
+    class QListWidget(QWidget):
+        def __init__(self, *a, **k):
+            self._items = []
+        def addItem(self, item):
+            self._items.append(item)
+        def clear(self):
+            self._items = []
+        def count(self):
+            return len(self._items)
+        def item(self, i):
+            return types.SimpleNamespace(text=lambda: self._items[i], isSelected=lambda: True)
+    class QTabWidget(QWidget):
+        def addTab(self, *a, **k):
+            pass
+    class QFileDialog: pass
+    class QMessageBox: pass
+    class QSystemTrayIcon:
+        def __init__(self, *a, **k):
+            pass
+    class QUrl: pass
+    Qt = types.SimpleNamespace(MouseButton=types.SimpleNamespace(LeftButton=1), CaseSensitivity=types.SimpleNamespace(CaseInsensitive=0), AlignmentFlag=types.SimpleNamespace(AlignLeft=0))
+    def Slot(*a, **k):
+        def decorator(fn):
+            return fn
+        return decorator
+    qtcore = types.SimpleNamespace(QObject=object, Signal=lambda *a, **k: _Signal(), QThread=object, QTimer=object, QDir=QDir, Qt=Qt, Slot=Slot, QMutex=object, QUrl=QUrl)
+    qtwidgets = types.SimpleNamespace(QApplication=QApplication, QWidget=QWidget, QVBoxLayout=QVBoxLayout, QHBoxLayout=QVBoxLayout, QTabWidget=QTabWidget, QLabel=QLabel, QProgressBar=QProgressBar, QPushButton=QPushButton, QCheckBox=QCheckBox, QSpinBox=QSpinBox, QListWidget=QListWidget, QGroupBox=QGroupBox, QFileDialog=QFileDialog, QMessageBox=QMessageBox, QSystemTrayIcon=QSystemTrayIcon)
+    qtgui = types.SimpleNamespace(QIcon=object)
+    qtmultimedia = types.SimpleNamespace(QSoundEffect=object)
+    sys.modules['PySide6'] = types.SimpleNamespace(QtCore=qtcore, QtWidgets=qtwidgets, QtGui=qtgui)
+    sys.modules['PySide6.QtCore'] = qtcore
+    sys.modules['PySide6.QtWidgets'] = qtwidgets
+    sys.modules['PySide6.QtGui'] = qtgui
+    sys.modules['PySide6.QtMultimedia'] = qtmultimedia

--- a/tests/test_processors_tab_connections.py
+++ b/tests/test_processors_tab_connections.py
@@ -1,0 +1,58 @@
+import sys
+import types
+
+# Ensure package path
+sys.path.insert(0, 'CorpusBuilderApp')
+
+from PySide6.QtWidgets import QApplication
+
+# Stub heavy wrapper modules before importing the tab module
+class_names = {
+    'shared_tools.ui_wrappers.processors.batch_nonpdf_extractor_enhanced_wrapper': 'BatchNonPDFExtractorEnhancedWrapper',
+    'shared_tools.ui_wrappers.processors.pdf_extractor_wrapper': 'PDFExtractorWrapper',
+    'shared_tools.ui_wrappers.processors.base_extractor_wrapper': 'BaseExtractorWrapper',
+    'shared_tools.ui_wrappers.processors.text_extractor_wrapper': 'TextExtractorWrapper',
+    'shared_tools.ui_wrappers.processors.batch_text_extractor_enhanced_prerefactor_wrapper': 'BatchTextExtractorEnhancedPrerefactorWrapper',
+    'shared_tools.ui_wrappers.processors.deduplicate_nonpdf_outputs_wrapper': 'DeduplicateNonPDFOutputsWrapper',
+    'shared_tools.ui_wrappers.processors.deduplicator_wrapper': 'DeduplicatorWrapper',
+    'shared_tools.ui_wrappers.processors.quality_control_wrapper': 'QualityControlWrapper',
+    'shared_tools.ui_wrappers.processors.corruption_detector_wrapper': 'CorruptionDetectorWrapper',
+    'shared_tools.ui_wrappers.processors.domain_classifier_wrapper': 'DomainClassifierWrapper',
+    'shared_tools.ui_wrappers.processors.domainsmanager_wrapper': 'DomainsManagerWrapper',
+    'shared_tools.ui_wrappers.processors.monitor_progress_wrapper': 'MonitorProgressWrapper',
+    'shared_tools.ui_wrappers.processors.machine_translation_detector_wrapper': 'MachineTranslationDetectorWrapper',
+    'shared_tools.ui_wrappers.processors.language_confidence_detector_wrapper': 'LanguageConfidenceDetectorWrapper',
+    'shared_tools.ui_wrappers.processors.financial_symbol_processor_wrapper': 'FinancialSymbolProcessorWrapper',
+    'shared_tools.ui_wrappers.processors.chart_image_extractor_wrapper': 'ChartImageExtractorWrapper',
+    'shared_tools.ui_wrappers.processors.formula_extractor_wrapper': 'FormulaExtractorWrapper',
+    'shared_tools.ui_wrappers.processors.corpus_balancer_wrapper': 'CorpusBalancerWrapper',
+}
+for name, cls_name in class_names.items():
+    mod = types.ModuleType(name)
+    setattr(mod, cls_name, type(cls_name, (), {}))
+    sys.modules[name] = mod
+
+# Stub NotificationManager to avoid heavy UI dependencies
+nm_mod = types.ModuleType('app.ui.tabs.corpus_manager_tab')
+nm_mod.NotificationManager = type('NotificationManager', (), {})
+sys.modules['app.ui.tabs.corpus_manager_tab'] = nm_mod
+
+from app.ui.tabs import processors_tab as pt
+
+class DummyIconManager:
+    def get_icon_path(self, *a, **k):
+        return None
+
+
+def test_selected_domain_button_connected(monkeypatch):
+    monkeypatch.setattr(pt, "IconManager", DummyIconManager)
+    app = QApplication.instance() or QApplication([])
+
+    tab = pt.ProcessorsTab.__new__(pt.ProcessorsTab)
+    tab.project_config = None
+    tab.processor_wrappers = {}
+    # Call the method under test
+    pt.ProcessorsTab.create_advanced_tab(tab)
+
+    assert hasattr(tab.apply_to_selected_btn.clicked, "_slots")
+    assert tab.apply_selected_domain in tab.apply_to_selected_btn.clicked._slots


### PR DESCRIPTION
## Summary
- hook up apply_to_selected_btn to a new slot
- add placeholder processing logic for selected domain
- provide minimal Qt stubs for tests
- verify button signal connection via unit test

## Testing
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_processors_tab_connections.py -q`
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6847103566ec8326aa45234e170f2a54