### PR TITLE
Add 'Rebalance Now' button to DashboardTab with signal

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
@@ -532,6 +532,32 @@ class DashboardTab(QWidget):
             btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
             btn.clicked.connect(slot)
             quick_actions_layout.addWidget(btn)
+
+        # Rebalance Now quick action
+        self.rebalance_now_btn = QPushButton("Rebalance Now")
+        self.rebalance_now_btn.setObjectName("action-btn")
+        self.rebalance_now_btn.setStyleSheet("""
+                QPushButton[objectName="action-btn"] {
+                    background-color: #32B8C6;
+                    color: white;
+                    border: none;
+                    border-radius: 8px;
+                    font-size: 14px;
+                    font-weight: 600;
+                    padding: 12px 16px;
+                }
+                QPushButton[objectName="action-btn"]:hover {
+                    background-color: #2DA6B2;
+                    transform: translateY(-1px);
+                }
+                QPushButton[objectName="action-btn"]:pressed {
+                    background-color: #248995;
+                }
+            """)
+        self.rebalance_now_btn.setFixedHeight(40)
+        self.rebalance_now_btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.rebalance_now_btn.clicked.connect(self.rebalance_requested.emit)
+        quick_actions_layout.addWidget(self.rebalance_now_btn)
         return quick_actions_card
 
     def create_corpus_health_widget(self):

--- a/CorpusBuilderApp/tests/ui/test_dashboard_tab.py
+++ b/CorpusBuilderApp/tests/ui/test_dashboard_tab.py
@@ -26,3 +26,14 @@ def test_view_all_activity_signal(dashboard_tab, qtbot):
     dashboard_tab.view_all_activity_requested.connect(on_request)
     qtbot.mouseClick(dashboard_tab.view_all_btn, Qt.MouseButton.LeftButton)
     assert triggered
+
+
+def test_rebalance_now_signal(dashboard_tab, qtbot):
+    triggered = []
+
+    def on_request():
+        triggered.append(True)
+
+    dashboard_tab.rebalance_requested.connect(on_request)
+    qtbot.mouseClick(dashboard_tab.rebalance_now_btn, Qt.MouseButton.LeftButton)
+    assert triggered


### PR DESCRIPTION
## Summary
- add `rebalance_now_btn` to DashboardTab quick actions
- emit `rebalance_requested` when clicked
- test that clicking "Rebalance Now" triggers the signal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_6847139c67e08326a24c33d60209d6fd