### PR TITLE
Add dynamic config refresh for collector wrappers

### DIFF
--- a/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/annas_archive_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/annas_archive_wrapper.py
@@ -41,13 +41,19 @@ class AnnasArchiveWrapper(BaseWrapper, CollectorWrapperMixin):
         super().start(**kwargs)
 
     def refresh_config(self):
-        """Re-apply configuration values from :class:`ProjectConfig`. Safe to call at any time."""
-        config = self.project_config.get(f"collectors.{self.name}", {})
-        for key, value in config.items():
+        """Reload parameters from ``self.config``. Safe to call multiple times."""
+        wrapper_cfg = self.config.get(f"collectors.{self.name}", {}) or {}
+
+        for key, value in wrapper_cfg.items():
             method = f"set_{key}"
             if hasattr(self, method):
                 try:
                     getattr(self, method)(value)
                 except Exception:
-                    pass
+                    continue
+
+        if self.collector:
+            cookie = self.config.get("api_keys.annas_cookie")
+            if cookie:
+                setattr(self.collector, "cookie", cookie)
 

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/arxiv_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/arxiv_wrapper.py
@@ -41,13 +41,18 @@ class ArxivWrapper(BaseWrapper, CollectorWrapperMixin):
         super().start(**kwargs)
 
     def refresh_config(self):
-        """Re-apply configuration values from :class:`ProjectConfig`. Safe to call at any time."""
-        config = self.project_config.get(f"collectors.{self.name}", {})
-        for key, value in config.items():
+        """Reload parameters from ``self.config`` such as search terms and limits."""
+        cfg = self.config.get(f"collectors.{self.name}", {}) or {}
+        for key, value in cfg.items():
             method = f"set_{key}"
             if hasattr(self, method):
                 try:
                     getattr(self, method)(value)
                 except Exception:
-                    pass
+                    continue
+
+        if self.collector:
+            email = self.config.get("api_keys.arxiv_email")
+            if email:
+                setattr(self.collector, "email", email)
 

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/bitmex_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/bitmex_wrapper.py
@@ -23,13 +23,17 @@ class BitMEXWrapper(BaseWrapper, CollectorWrapperMixin):
         return "collect"
 
     def refresh_config(self):
-        """Re-apply configuration values from :class:`ProjectConfig`. Safe to call at any time."""
-        config = self.project_config.get(f"collectors.{self.name}", {})
-        for key, value in config.items():
+        """Reload parameters and API credentials from ``self.config``."""
+        cfg = self.config.get(f"collectors.{self.name}", {}) or {}
+        for key, value in cfg.items():
             method = f"set_{key}"
             if hasattr(self, method):
                 try:
                     getattr(self, method)(value)
                 except Exception:
-                    pass
+                    continue
+
+        if self.collector:
+            self.collector.api_key = self.config.get("api_keys.bitmex_key")
+            self.collector.api_secret = self.config.get("api_keys.bitmex_secret")
 

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/fred_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/fred_wrapper.py
@@ -35,13 +35,18 @@ class FREDWrapper(BaseWrapper, CollectorWrapperMixin):
         super().start(**kwargs)
 
     def refresh_config(self):
-        """Re-apply configuration values from :class:`ProjectConfig`. Safe to call at any time."""
-        config = self.project_config.get(f"collectors.{self.name}", {})
-        for key, value in config.items():
+        """Reload series IDs and API key from configuration."""
+        cfg = self.config.get(f"collectors.{self.name}", {}) or {}
+        for key, value in cfg.items():
             method = f"set_{key}"
             if hasattr(self, method):
                 try:
                     getattr(self, method)(value)
                 except Exception:
-                    pass
+                    continue
+
+        if self.collector:
+            api_key = self.config.get("api_keys.fred_key")
+            if api_key:
+                self.collector.api_key = api_key
 

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/github_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/github_wrapper.py
@@ -48,14 +48,19 @@ class GitHubWrapper(BaseWrapper, CollectorWrapperMixin):
         super().start(**kwargs)
 
     def refresh_config(self):
-        """Re-apply configuration values from :class:`ProjectConfig`. Safe to call at any time."""
-        config = self.project_config.get(f"collectors.{self.name}", {})
-        for key, value in config.items():
+        """Reload search parameters and API credentials from configuration."""
+        cfg = self.config.get(f"collectors.{self.name}", {}) or {}
+        for key, value in cfg.items():
             method = f"set_{key}"
             if hasattr(self, method):
                 try:
                     getattr(self, method)(value)
                 except Exception:
-                    pass
+                    continue
+
+        if self.collector:
+            token = self.config.get("api_keys.github_token")
+            if token:
+                self.collector.api_key = token
 
 

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/isda_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/isda_wrapper.py
@@ -31,13 +31,17 @@ class ISDAWrapper(BaseWrapper, CollectorWrapperMixin):
         self.max_sources = max_sources
 
     def refresh_config(self):
-        """Re-apply configuration values from :class:`ProjectConfig`. Safe to call at any time."""
-        config = self.project_config.get(f"collectors.{self.name}", {})
-        for key, value in config.items():
+        """Reload configuration parameters and credentials."""
+        cfg = self.config.get(f"collectors.{self.name}", {}) or {}
+        for key, value in cfg.items():
             method = f"set_{key}"
             if hasattr(self, method):
                 try:
                     getattr(self, method)(value)
                 except Exception:
-                    pass
+                    continue
+
+        if self.collector:
+            self.collector.username = self.config.get("api_keys.isda_username")
+            self.collector.password = self.config.get("api_keys.isda_password")
 

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/quantopian_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/quantopian_wrapper.py
@@ -23,14 +23,14 @@ class QuantopianWrapper(BaseWrapper, CollectorWrapperMixin):
         return "collect"
 
     def refresh_config(self):
-        """Re-apply configuration values from :class:`ProjectConfig`. Safe to call at any time."""
-        config = self.project_config.get(f"collectors.{self.name}", {})
-        for key, value in config.items():
+        """Reload configuration values from ``self.config``."""
+        cfg = self.config.get(f"collectors.{self.name}", {}) or {}
+        for key, value in cfg.items():
             method = f"set_{key}"
             if hasattr(self, method):
                 try:
                     getattr(self, method)(value)
                 except Exception:
-                    pass
+                    continue
 
 

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/scidb_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/scidb_wrapper.py
@@ -23,13 +23,13 @@ class SciDBWrapper(BaseWrapper, CollectorWrapperMixin):
         return "collect"
 
     def refresh_config(self):
-        """Re-apply configuration values from :class:`ProjectConfig`. Safe to call at any time."""
-        config = self.project_config.get(f"collectors.{self.name}", {})
-        for key, value in config.items():
+        """Reload collector options from configuration."""
+        cfg = self.config.get(f"collectors.{self.name}", {}) or {}
+        for key, value in cfg.items():
             method = f"set_{key}"
             if hasattr(self, method):
                 try:
                     getattr(self, method)(value)
                 except Exception:
-                    pass
+                    continue
 

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/web_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/collectors/web_wrapper.py
@@ -35,13 +35,13 @@ class WebWrapper(BaseWrapper, CollectorWrapperMixin):
         super().start(**kwargs)
 
     def refresh_config(self):
-        """Re-apply configuration values from :class:`ProjectConfig`. Safe to call at any time."""
-        config = self.project_config.get(f"collectors.{self.name}", {})
-        for key, value in config.items():
+        """Reload configuration parameters such as URL list."""
+        cfg = self.config.get(f"collectors.{self.name}", {}) or {}
+        for key, value in cfg.items():
             method = f"set_{key}"
             if hasattr(self, method):
                 try:
                     getattr(self, method)(value)
                 except Exception:
-                    pass
+                    continue
 


### PR DESCRIPTION
## Summary
- refresh parameters from configuration in all collector wrappers

## Testing
- `pytest -k "nonexistingpattern" -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'QtTest')*

------
https://chatgpt.com/codex/tasks/task_e_684716764154832686954314d0c3f974