### PR TITLE
Implement ActivityLogService and log configuration updates

### DIFF
--- a/CorpusBuilderApp/shared_tools/services/activity_log_service.py
+++ b/CorpusBuilderApp/shared_tools/services/activity_log_service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime
+from PySide6.QtCore import QObject, Signal as pyqtSignal
+
+
+class ActivityLogService(QObject):
+    """Lightweight service for tracking application activity."""
+
+    activity_added = pyqtSignal(dict)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._entries: list[dict] = []
+
+    def log(self, source: str, message: str, details: object | None = None) -> None:
+        """Record a log entry and emit an update signal."""
+        entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "source": source,
+            "message": message,
+            "details": details,
+        }
+        self._entries.append(entry)
+        self.activity_added.emit(entry)
+
+    def load_recent(self, n: int = 20) -> list[dict]:
+        """Return the most recent ``n`` log entries."""
+        return self._entries[-n:]


### PR DESCRIPTION
## Summary
- add an `ActivityLogService` to track recent activities
- instantiate `ActivityLogService` in the main window
- log configuration saves and collector refreshes after balancing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847170d644c83268b43719398086d4c