### PR TITLE
Connect ActivityLogService to dashboard recent activity

### DIFF
--- a/CorpusBuilderApp/app/main_window.py
+++ b/CorpusBuilderApp/app/main_window.py
@@ -109,7 +109,7 @@ class CryptoCorpusMainWindow(QMainWindow):
             )
             # Dashboard tab
             self.logger.debug("Initializing DashboardTab...")
-            self.dashboard_tab = DashboardTab(self.config)
+            self.dashboard_tab = DashboardTab(self.config, self.activity_log_service)
             self.logger.debug("DashboardTab initialized successfully")
             self.tab_widget.addTab(self.dashboard_tab, "📊 Dashboard")
             # Collectors tab


### PR DESCRIPTION
## Summary
- pass ActivityLogService into `DashboardTab`
- expose `recent_activity_widget` and connect the `activity_added` signal
- instantiate `DashboardTab` with the service from `CryptoCorpusMainWindow`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_6847251d5398832689f8c491600dc586