### PR TITLE
feat: add default refresh_config() to BaseWrapper and missing wrappers

### DIFF
--- a/CorpusBuilderApp/shared_tools/ui_wrappers/base_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/base_wrapper.py
@@ -118,6 +118,10 @@ class BaseWrapper(QObject):
         """Check if operation is currently running"""
         return self._is_running
 
+    def refresh_config(self):
+        """Default no-op implementation; can be overridden by subclasses."""
+        pass
+
 class CollectorWrapperMixin:
     """Mixin for collector-specific functionality"""
     

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/base_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/base_extractor_wrapper.py
@@ -537,5 +537,9 @@ class BaseExtractorWrapper(BaseWrapper):
             return False
         if config['memory_limit_mb'] <= 0:
             return False
-            
+
         return True
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/batch_nonpdf_extractor_enhanced_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/batch_nonpdf_extractor_enhanced_wrapper.py
@@ -336,3 +336,7 @@ class BatchNonPDFExtractorEnhancedWrapper(BaseWrapper, ProcessorWrapperMixin):
     def is_processing(self) -> bool:
         """Check if processing is currently active"""
         return self.worker is not None and self.worker.isRunning()
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/batch_text_extractor_enhanced_prerefactor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/batch_text_extractor_enhanced_prerefactor_wrapper.py
@@ -734,3 +734,7 @@ class BatchTextExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
     def is_processing(self) -> bool:
         """Check if processing is currently active"""
         return self.worker is not None and self.worker.isRunning()
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/chart_image_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/chart_image_extractor_wrapper.py
@@ -74,6 +74,10 @@ class ChartImageExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
             f"Chart extraction completed: {total_charts} charts extracted from {len(results)} files"
         )
 
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass
+
 class ChartExtractorWorkerThread(QThread):
     """Worker thread for chart extraction processing."""
     

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/corpus_balancer_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/corpus_balancer_wrapper.py
@@ -192,3 +192,7 @@ class CorpusBalancerWrapper(BaseWrapper, ProcessorWrapperMixin):
 
         # Notify the UI about updates
         self.status_updated.emit("Updated collector configs based on imbalance analysis")
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/corruption_detector_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/corruption_detector_wrapper.py
@@ -699,3 +699,7 @@ class CorruptionDetectorWrapper(BaseWrapper, ProcessorWrapperMixin):
     def is_scanning(self) -> bool:
         """Check if scan is currently active"""
         return self.worker is not None and self.worker.isRunning()
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/deduplicate_nonpdf_outputs_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/deduplicate_nonpdf_outputs_wrapper.py
@@ -647,3 +647,7 @@ class DeduplicateNonPDFOutputsWrapper(BaseWrapper, ProcessorWrapperMixin):
     def is_processing(self) -> bool:
         """Check if processing is currently active"""
         return self.worker is not None and self.worker.isRunning()
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/deduplicator_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/deduplicator_wrapper.py
@@ -89,7 +89,11 @@ class DeduplicatorWrapper(BaseWrapper, ProcessorWrapperMixin):
         self.status_updated.emit(
             f"Deduplication completed: {len(results.get('duplicate_sets', []))} duplicate sets found"
         )
-        
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass
+
     @pyqtSlot()
     def start_deduplication(self):
         # Automatically generate title cache before deduplication

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domain_classifier_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domain_classifier_wrapper.py
@@ -81,6 +81,10 @@ class DomainClassifierWrapper(BaseWrapper, ProcessorWrapperMixin):
             f"Domain classification completed: {len(results)} documents classified"
         )
 
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass
+
 class DomainClassifierWorkerThread(QThread):
     """Worker thread for domain classification processing."""
     

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domainsmanager_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domainsmanager_wrapper.py
@@ -1017,3 +1017,7 @@ class DomainsManagerWrapper(BaseWrapper, ProcessorWrapperMixin):
     def is_processing(self) -> bool:
         """Check if any operation is currently active"""
         return self.worker is not None and self.worker.isRunning()
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/financial_symbol_processor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/financial_symbol_processor_wrapper.py
@@ -82,6 +82,10 @@ class FinancialSymbolProcessorWrapper(BaseWrapper, ProcessorWrapperMixin):
             f"Financial symbol extraction completed: {total_symbols} symbols extracted from {len(results)} files"
         )
 
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass
+
 class FinancialSymbolWorkerThread(QThread):
     """Worker thread for financial symbol extraction processing."""
     

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/formula_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/formula_extractor_wrapper.py
@@ -74,6 +74,10 @@ class FormulaExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
             f"Formula extraction completed: {total_formulas} formulas extracted from {len(results)} files"
         )
 
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass
+
 class FormulaExtractorWorkerThread(QThread):
     """Worker thread for formula extraction processing."""
     

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/language_confidence_detector_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/language_confidence_detector_wrapper.py
@@ -81,6 +81,10 @@ class LanguageConfidenceDetectorWrapper(BaseWrapper, ProcessorWrapperMixin):
             f"Language detection completed: {len(results)} files processed"
         )
 
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass
+
 class LanguageDetectorWorkerThread(QThread):
     """Worker thread for language detection processing."""
     

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/machine_translation_detector_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/machine_translation_detector_wrapper.py
@@ -82,6 +82,10 @@ class MachineTranslationDetectorWrapper(BaseWrapper, ProcessorWrapperMixin):
             f"Machine translation detection completed: {translated_count} translated documents found in {len(results)} files"
         )
 
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass
+
 class MTDetectorWorkerThread(QThread):
     """Worker thread for machine translation detection processing."""
     

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/monitor_progress_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/monitor_progress_wrapper.py
@@ -743,3 +743,7 @@ class MonitorProgressWrapper(BaseWrapper, ProcessorWrapperMixin):
         """Export history to JSON format"""
         # TODO: Implement JSON export logic
         pass
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/pdf_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/pdf_extractor_wrapper.py
@@ -144,3 +144,7 @@ class PDFExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
             return {"files_processed": self.extractor.files_processed,
                     "ocr_used_count": self.extractor.ocr_used_count}
         return {"files_processed": 0, "ocr_used_count": 0}
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/quality_control_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/quality_control_wrapper.py
@@ -87,7 +87,11 @@ class QualityControlWrapper(BaseWrapper, ProcessorWrapperMixin):
         
     def _on_status_updated(self, *args, **kwargs):
         pass
-        
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass
+
 class QCWorkerThread(QThread):
     """Worker thread for quality control processing."""
     

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/text_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/text_extractor_wrapper.py
@@ -129,3 +129,7 @@ class TextExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
         if self.extractor:
             return {"formats_processed": self.extractor.format_counts}
         return {"formats_processed": {}}
+
+    def refresh_config(self):
+        """Reload parameters from ``self.config``. Placeholder for future use."""
+        pass


### PR DESCRIPTION
## Summary
- add refresh_config() default implementation to BaseWrapper
- provide placeholder refresh_config() methods on all processor wrappers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68472537969883268cccf514617cf42a