### PR TITLE
Enable stats service test

### DIFF
--- a/CorpusBuilderApp/tests/unit/test_corpus_stats_service.py
+++ b/CorpusBuilderApp/tests/unit/test_corpus_stats_service.py
@@ -1,8 +1,34 @@
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
 import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
 from shared_tools.services.corpus_stats_service import CorpusStatsService
 
-@pytest.mark.skip("Pending corpus scan test")
+
 def test_refresh_stats(tmp_path):
-    service = CorpusStatsService(project_config=type('Cfg',(object,),{'get_corpus_dir':lambda self: tmp_path}))
+    """Ensure stats are loaded from JSON and signal emitted."""
+    stats = {"documents": 5}
+    stats_file = tmp_path / "corpus_stats.json"
+    with open(stats_file, "w", encoding="utf-8") as fh:
+        json.dump(stats, fh)
+
+    cfg = type("Cfg", (object,), {"get_corpus_dir": lambda self: tmp_path})
+    service = CorpusStatsService.__new__(CorpusStatsService)
+    service.project_config = cfg()
+    service.corpus_manager = None
+    service.logger = MagicMock()
+    service.stats = {}
+    service.stats_updated = MagicMock()
+    service.stats_updated.emit = MagicMock()
+
     service.refresh_stats()
-    assert service.stats == {} or isinstance(service.stats, dict)
+
+    assert service.stats == stats
+    service.stats_updated.emit.assert_called_once_with(stats)


### PR DESCRIPTION
## Summary
- remove skip and build a temporary stats JSON file
- verify refresh_stats loads it and emits the signal

## Testing
- `pytest CorpusBuilderApp/tests/unit/test_corpus_stats_service.py -q -p no:pytest-qt -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_684729cff1608326817d330062fd8d1b