### PR TITLE
Add minimal tests for core services

### DIFF
--- a/CorpusBuilderApp/tests/ui/test_dashboard_tab_rebalance.py
+++ b/CorpusBuilderApp/tests/ui/test_dashboard_tab_rebalance.py
@@ -1,0 +1,16 @@
+import pytest
+from PySide6.QtCore import Qt
+from app.ui.tabs.dashboard_tab import DashboardTab
+
+@pytest.fixture
+def dashboard_tab(qapp, mock_project_config, qtbot):
+    tab = DashboardTab(mock_project_config)
+    qtbot.addWidget(tab)
+    return tab
+
+
+def test_rebalance_emits_signal(dashboard_tab, qtbot):
+    triggered = []
+    dashboard_tab.rebalance_requested.connect(lambda: triggered.append(True))
+    qtbot.mouseClick(dashboard_tab.rebalance_now_btn, Qt.MouseButton.LeftButton)
+    assert triggered

--- a/CorpusBuilderApp/tests/unit/test_activity_log_service.py
+++ b/CorpusBuilderApp/tests/unit/test_activity_log_service.py
@@ -1,0 +1,10 @@
+import pytest
+from shared_tools.services.activity_log_service import ActivityLogService
+
+def test_log_records_and_emits(qapp):
+    service = ActivityLogService()
+    received = []
+    service.activity_added.connect(lambda e: received.append(e))
+    service.log("test", "message", {"a":1})
+    assert received
+    assert service.load_recent(1)[0] == received[0]

--- a/CorpusBuilderApp/tests/unit/test_corpus_stats_service_refresh.py
+++ b/CorpusBuilderApp/tests/unit/test_corpus_stats_service_refresh.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+from shared_tools.services.corpus_stats_service import CorpusStatsService
+
+class DummyCfg:
+    def __init__(self, path: Path):
+        self._path = path
+    def get_stats_path(self):
+        return str(self._path)
+
+
+def test_refresh_reads_json_and_emits(tmp_path, qapp):
+    stats_file = tmp_path / "stats.json"
+    data = {"total": 3}
+    stats_file.write_text(json.dumps(data))
+    cfg = DummyCfg(stats_file)
+    service = CorpusStatsService(cfg)
+    received = []
+    service.stats_updated.connect(lambda s: received.append(s))
+    service.refresh_stats()
+    assert service.stats == data
+    assert received and received[0] == data


### PR DESCRIPTION
## Summary
- add activity log service tests
- test `CorpusStatsService.refresh_stats` JSON path handling
- verify dashboard rebalance signal triggers

## Testing
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684729eefa2483268ff93c8d0208f709