### PR TITLE
Add collectors tab integration tests

### DIFF
--- a/CorpusBuilderApp/tests/conftest.py
+++ b/CorpusBuilderApp/tests/conftest.py
@@ -19,10 +19,14 @@ qtcore = types.SimpleNamespace(
     QDir=object,
 )
 qtwidgets = types.SimpleNamespace(QApplication=type("QApplication", (), {"instance": staticmethod(lambda: None), "__init__": lambda self, *a, **k: None, "quit": lambda self: None}))
+qttest = types.SimpleNamespace(QTest=object, QSignalSpy=object)
 
-sys.modules.setdefault("PySide6", types.SimpleNamespace(QtCore=qtcore, QtWidgets=qtwidgets))
+sys.modules.setdefault(
+    "PySide6", types.SimpleNamespace(QtCore=qtcore, QtWidgets=qtwidgets, QtTest=qttest)
+)
 sys.modules.setdefault("PySide6.QtCore", qtcore)
 sys.modules.setdefault("PySide6.QtWidgets", qtwidgets)
+sys.modules.setdefault("PySide6.QtTest", qttest)
 for mod in [
     "fitz",
     "pytesseract",

--- a/CorpusBuilderApp/tests/ui/test_collectors_tab_integration.py
+++ b/CorpusBuilderApp/tests/ui/test_collectors_tab_integration.py
@@ -1,19 +1,47 @@
-import pytest
-from PySide6.QtWidgets import QApplication
+from unittest.mock import MagicMock, patch
+
 from app.ui.tabs.collectors_tab import CollectorsTab
 
-@pytest.mark.skip("Audit stub – implement later")
-def test_collectors_tab_sequential_flow(qtbot, monkeypatch):
+
+def test_collectors_tab_sequential_flow(qtbot):
     """Verify tab signals integrate across multiple collectors."""
-    # TODO: create mock ProjectConfig and collectors
-    # TODO: trigger start/stop via UI and assert status updates
-    pass
+    pc = MagicMock()
+    with patch('app.ui.tabs.collectors_tab.ISDAWrapper') as mock_isda, \
+         patch('app.ui.tabs.collectors_tab.GitHubWrapper') as mock_github:
+        isda_wrapper = MagicMock()
+        github_wrapper = MagicMock()
+        mock_isda.return_value = isda_wrapper
+        mock_github.return_value = github_wrapper
+
+        tab = CollectorsTab(pc)
+        qtbot.addWidget(tab)
+
+        started = []
+        finished = []
+        tab.collection_started.connect(lambda n: started.append(n))
+        tab.collection_finished.connect(lambda n, s: finished.append((n, s)))
+
+        tab.start_collection('isda')
+        isda_wrapper.start.assert_called_once()
+        pc.set.assert_called_with('collectors.isda.running', True)
+        assert not tab.cards['isda'].start_btn.isEnabled()
+        assert tab.cards['isda'].stop_btn.isEnabled()
+
+        tab.stop_collection('isda')
+        isda_wrapper.stop.assert_called_once()
+        pc.set.assert_called_with('collectors.isda.running', False)
+
+        tab.start_collection('github')
+        github_wrapper.start.assert_called_once()
+        tab.on_collection_completed('github', {'docs': 1})
+        pc.set.assert_called_with('collectors.github.running', False)
+
+        assert started == ['isda', 'github']
+        assert finished[-1] == ('github', True)
 
 
-@pytest.mark.skip("Integration placeholder - collector state")
 def test_collectors_tab_persists_state(qtbot):
     """Collector completion should update ProjectConfig."""
-    from unittest.mock import MagicMock
     pc = MagicMock()
     tab = CollectorsTab(pc)
     qtbot.addWidget(tab)


### PR DESCRIPTION
## Summary
- implement integration tests for collectors tab
- extend Qt stubs to include QtTest

## Testing
- `ruff check CorpusBuilderApp/tests/ui/test_collectors_tab_integration.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts= CorpusBuilderApp/tests/ui/test_collectors_tab_integration.py::test_collectors_tab_sequential_flow -vv` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68472a48e8a883268b10ce257f5471be