### PR TITLE
Fix inconsistent test imports

### DIFF
--- a/CorpusBuilderApp/tests/conftest.py
+++ b/CorpusBuilderApp/tests/conftest.py
@@ -102,9 +102,10 @@ sys.modules.setdefault("PIL", dummy_pil)
 sys.modules.setdefault("PIL.Image", dummy_image_mod)
 sys.modules.setdefault("PIL.ImageEnhance", dummy_enhance_mod)
 
-# Add the app directory to the Python path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'app'))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'shared_tools'))
+# Ensure the package root is on the Python path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import QDir

--- a/CorpusBuilderApp/tests/test_domain_classifier_wrapper.py
+++ b/CorpusBuilderApp/tests/test_domain_classifier_wrapper.py
@@ -13,9 +13,7 @@ import pytest
 from unittest.mock import Mock, patch, MagicMock
 from pathlib import Path
 
-# Add project root to path
-project_root = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(project_root))
+
 
 from PySide6.QtCore import QObject, Signal as pyqtSignal
 from PySide6.QtWidgets import QApplication

--- a/CorpusBuilderApp/tests/ui/test_analytics_tab.py
+++ b/CorpusBuilderApp/tests/ui/test_analytics_tab.py
@@ -4,7 +4,6 @@ import pytest
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import Qt
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 from app.ui.tabs.analytics_tab import AnalyticsTab
 from app.ui.widgets.card_wrapper import CardWrapper
 from app.ui.widgets.section_header import SectionHeader

--- a/CorpusBuilderApp/tests/ui/test_logs_tab.py
+++ b/CorpusBuilderApp/tests/ui/test_logs_tab.py
@@ -3,7 +3,6 @@ import sys
 import pytest
 from PySide6.QtCore import Qt
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 from app.ui.tabs.logs_tab import LogsTab
 from app.ui.widgets.card_wrapper import CardWrapper
 from app.ui.widgets.section_header import SectionHeader

--- a/CorpusBuilderApp/tests/unit/test_cli_consolidate.py
+++ b/CorpusBuilderApp/tests/unit/test_cli_consolidate.py
@@ -4,10 +4,7 @@ import types
 from typing import List
 import yaml
 
-# Add project root and package paths
-root = _Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(root))
-sys.path.insert(1, str(root / "CorpusBuilderApp"))
+
 
 # Stub heavy dependencies required by imported modules
 qtcore = types.SimpleNamespace(QObject=object, Signal=lambda *a, **k: lambda *a, **k: None, QThread=object, QTimer=object)

--- a/CorpusBuilderApp/tests/unit/test_corpus_stats_service.py
+++ b/CorpusBuilderApp/tests/unit/test_corpus_stats_service.py
@@ -6,8 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT))
+
 
 from shared_tools.services.corpus_stats_service import CorpusStatsService
 

--- a/tests/cli/test_execute_from_config.py
+++ b/tests/cli/test_execute_from_config.py
@@ -4,10 +4,7 @@ import types
 from typing import List
 import yaml
 
-# Add project root and package paths
-root = _Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(root))
-sys.path.insert(1, str(root / "CorpusBuilderApp"))
+
 
 # Stub heavy dependencies required by imported modules
 qtcore = types.SimpleNamespace(QObject=object, Signal=lambda *a, **k: lambda *a, **k: None, QThread=object, QTimer=object)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,16 @@ import tempfile
 import shutil
 import pytest
 
-# Ensure app and shared_tools packages are importable
+# Ensure project packages are importable
 base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, os.path.join(base_dir, 'CorpusBuilderApp'))
-sys.path.insert(0, os.path.join(base_dir, 'CorpusBuilderApp', 'shared_tools'))
+if base_dir not in sys.path:
+    sys.path.insert(0, base_dir)
+project_root = os.path.join(base_dir, 'CorpusBuilderApp')
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+shared_tools_path = os.path.join(project_root, 'shared_tools')
+if shared_tools_path not in sys.path:
+    sys.path.insert(0, shared_tools_path)
 
 if 'PySide6' not in sys.modules:
     class _Signal:

--- a/tests/test_processors_tab_connections.py
+++ b/tests/test_processors_tab_connections.py
@@ -1,9 +1,6 @@
 import sys
 import types
 
-# Ensure package path
-sys.path.insert(0, 'CorpusBuilderApp')
-
 from PySide6.QtWidgets import QApplication
 
 # Stub heavy wrapper modules before importing the tab module

--- a/tests/wrappers/test_worker_threads.py
+++ b/tests/wrappers/test_worker_threads.py
@@ -4,10 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 import pytest
 
-# Add project paths for imports
-root = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(root))
-sys.path.insert(1, str(root / "CorpusBuilderApp"))
+
 
 # Stub heavy third-party dependencies
 dummy = types.ModuleType("dummy")


### PR DESCRIPTION
## Summary
- unify sys.path modifications in tests by using project root
- remove scattered path tweaks from test files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_684733754b8c8326b03e1a5644b31ba7