### PR TITLE
Adjust sys.path logic in tests

### DIFF
--- a/CorpusBuilderApp/tests/conftest.py
+++ b/CorpusBuilderApp/tests/conftest.py
@@ -102,7 +102,7 @@ sys.modules.setdefault("PIL", dummy_pil)
 sys.modules.setdefault("PIL.Image", dummy_image_mod)
 sys.modules.setdefault("PIL.ImageEnhance", dummy_enhance_mod)
 
-# Ensure the package root is on the Python path
+# Ensure the CorpusBuilderApp root is on the Python path
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,16 +5,10 @@ import tempfile
 import shutil
 import pytest
 
-# Ensure project packages are importable
-base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if base_dir not in sys.path:
-    sys.path.insert(0, base_dir)
-project_root = os.path.join(base_dir, 'CorpusBuilderApp')
+# Ensure the CorpusBuilderApp root is on the Python path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'CorpusBuilderApp'))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
-shared_tools_path = os.path.join(project_root, 'shared_tools')
-if shared_tools_path not in sys.path:
-    sys.path.insert(0, shared_tools_path)
 
 if 'PySide6' not in sys.modules:
     class _Signal:


### PR DESCRIPTION
## Summary
- simplify test setup by adding only the CorpusBuilderApp root to `sys.path`
- remove redundant path insertion logic in other test config

## Testing
- `pytest -q --disable-warnings CorpusBuilderApp/tests/ui/test_dashboard_tab.py CorpusBuilderApp/tests/test_file_browser.py` *(fails: ImportError: cannot import name 'QFrame' from '<unknown module name>')*


------
https://chatgpt.com/codex/tasks/task_e_6847379dc93c8326b384f436507023fa