### PR TITLE
Fix dashboard signal to open activity tab

### DIFF
--- a/CorpusBuilderApp/app/main_window.py
+++ b/CorpusBuilderApp/app/main_window.py
@@ -370,6 +370,7 @@ class CryptoCorpusMainWindow(QMainWindow):
     def show_full_activity_tab(self):
         """Show the full activity tab when View All is clicked"""
         try:
+            print("[DEBUG] show_full_activity_tab called")
             # Check if Full Activity tab already exists
             for i in range(self.tab_widget.count()):
                 if self.tab_widget.tabText(i) == "📊 Full Activity":

--- a/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
@@ -374,10 +374,11 @@ class DashboardTab(QWidget):
         main_layout.addWidget(scroll_area)
         button_layout = QHBoxLayout()
         button_layout.addStretch()
-        view_all_btn = QPushButton('View All Activity')
-        view_all_btn.setStyleSheet('background-color: #2d3748; color: #32B8C6; border: none; border-radius: 4px; padding: 6px 12px; font-size: 11px;')
-        view_all_btn.clicked.connect(self.view_all_activity_requested.emit)
-        button_layout.addWidget(view_all_btn)
+        # Expose the button for testing and proper signal emission
+        self.view_all_btn = QPushButton('View All Activity')
+        self.view_all_btn.setStyleSheet('background-color: #2d3748; color: #32B8C6; border: none; border-radius: 4px; padding: 6px 12px; font-size: 11px;')
+        self.view_all_btn.clicked.connect(lambda: self.view_all_activity_requested.emit())
+        button_layout.addWidget(self.view_all_btn)
         main_layout.addLayout(button_layout)
         return container
 


### PR DESCRIPTION
## Summary
- properly expose "View All Activity" button for DashboardTab
- ensure button emits `view_all_activity_requested`
- add debug print when opening the Full Activity tab

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_684739d5432083268d1cd64bb4382460