### PR TITLE
Fix test stubs and path setup

### DIFF
--- a/CorpusBuilderApp/tests/conftest.py
+++ b/CorpusBuilderApp/tests/conftest.py
@@ -7,67 +7,101 @@ import tempfile
 import shutil
 import json
 
-# Provide lightweight Qt stubs if PySide6 is unavailable
-class _DummySignal:
-    def emit(self, *a, **k):
+# Ensure repo root is importable when running tests individually
+base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if base_dir not in sys.path:
+    sys.path.insert(0, base_dir)
+
+# Alias for legacy imports
+sys.modules.setdefault(
+    "CryptoFinanceCorpusBuilder",
+    types.ModuleType("CryptoFinanceCorpusBuilder"),
+)
+sys.modules.setdefault(
+    "CryptoFinanceCorpusBuilder.shared_tools",
+    __import__("CorpusBuilderApp.shared_tools", fromlist=["dummy"]),
+)
+
+try:
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # pragma: no cover
+    def load_dotenv(*args, **kwargs):
         pass
+    stub = types.ModuleType("dotenv")
+    stub.load_dotenv = load_dotenv
+    sys.modules.setdefault("dotenv", stub)
 
-qtcore = types.SimpleNamespace(
-    QObject=object,
-    Signal=lambda *a, **k: _DummySignal(),
-    QThread=object,
-    QTimer=object,
-    Slot=lambda *a, **k: lambda *a, **k: None,
-    QDir=object,
-    Property=object,
-    __version__="6.5.0",
-    qVersion=lambda: "6.5.0",
-    qDebug=lambda *a, **k: None,
-    qWarning=lambda *a, **k: None,
-    qCritical=lambda *a, **k: None,
-    qFatal=lambda *a, **k: None,
-    qInfo=lambda *a, **k: None,
-    qInstallMessageHandler=lambda *a, **k: None,
-)
+# Provide lightweight Qt stubs if requested
+if os.environ.get("PYTEST_QT_STUBS") == "1":
+    print("Loaded PySide6 stub")
 
-qtwidgets = types.SimpleNamespace(
-    QApplication=type("QApplication", (), {
-        "instance": staticmethod(lambda: None),
-        "__init__": lambda self, *a, **k: None,
-        "quit": lambda self: None
-    }),
-    QWidget=object,
-    QVBoxLayout=object,
-    QHBoxLayout=object,
-    QTabWidget=object,
-    QLabel=object,
-    QProgressBar=object,
-    QPushButton=object,
-    QCheckBox=object,
-    QSpinBox=object,
-    QListWidget=object,
-    QTreeView=object,
-    QGroupBox=object,
-    QFileDialog=object,
-    QMessageBox=object,
-    QSystemTrayIcon=object,
-)
+    class _DummySignal:
+        def emit(self, *a, **k):
+            pass
 
-qtgui = types.SimpleNamespace(QIcon=object)
-qttest = types.SimpleNamespace(QTest=object, QSignalSpy=object)
-qtmultimedia = types.SimpleNamespace(QSoundEffect=object)
+    qtcore = types.SimpleNamespace(
+        QObject=object,
+        Signal=lambda *a, **k: _DummySignal(),
+        QThread=object,
+        QTimer=object,
+        Slot=lambda *a, **k: lambda *a, **k: None,
+        QDir=object,
+        Property=object,
+        __version__="6.5.0",
+        qVersion=lambda: "6.5.0",
+        qDebug=lambda *a, **k: None,
+        qWarning=lambda *a, **k: None,
+        qCritical=lambda *a, **k: None,
+        qFatal=lambda *a, **k: None,
+        qInfo=lambda *a, **k: None,
+        qInstallMessageHandler=lambda *a, **k: None,
+    )
 
-sys.modules.setdefault("PySide6", types.SimpleNamespace(
-    QtCore=qtcore,
-    QtWidgets=qtwidgets,
-    QtGui=qtgui,
-    QtTest=qttest
-))
-sys.modules.setdefault("PySide6.QtCore", qtcore)
-sys.modules.setdefault("PySide6.QtWidgets", qtwidgets)
-sys.modules.setdefault("PySide6.QtGui", qtgui)
-sys.modules.setdefault("PySide6.QtTest", qttest)
-sys.modules.setdefault("PySide6.QtMultimedia", qtmultimedia)
+    qtwidgets = types.SimpleNamespace(
+        QApplication=type("QApplication", (), {
+            "instance": staticmethod(lambda: None),
+            "__init__": lambda self, *a, **k: None,
+            "quit": lambda self: None
+        }),
+        QWidget=object,
+        QVBoxLayout=object,
+        QHBoxLayout=object,
+        QTabWidget=object,
+        QLabel=object,
+        QProgressBar=object,
+        QPushButton=object,
+        QCheckBox=object,
+        QSpinBox=object,
+        QListWidget=object,
+        QTreeView=object,
+        QGroupBox=object,
+        QFrame=object,
+        QLineEdit=object,
+        QComboBox=object,
+        QGridLayout=object,
+        QTextEdit=object,
+        QTableWidget=object,
+        QSplitter=object,
+        QFileDialog=object,
+        QMessageBox=object,
+        QSystemTrayIcon=object,
+    )
+
+    qtgui = types.SimpleNamespace(QIcon=object)
+    qttest = types.SimpleNamespace(QTest=object, QSignalSpy=object)
+    qtmultimedia = types.SimpleNamespace(QSoundEffect=object)
+
+    sys.modules.setdefault("PySide6", types.SimpleNamespace(
+        QtCore=qtcore,
+        QtWidgets=qtwidgets,
+        QtGui=qtgui,
+        QtTest=qttest
+    ))
+    sys.modules.setdefault("PySide6.QtCore", qtcore)
+    sys.modules.setdefault("PySide6.QtWidgets", qtwidgets)
+    sys.modules.setdefault("PySide6.QtGui", qtgui)
+    sys.modules.setdefault("PySide6.QtTest", qttest)
+    sys.modules.setdefault("PySide6.QtMultimedia", qtmultimedia)
 
 # Mock external modules
 for mod in [

--- a/CorpusBuilderApp/tests/integration/test_error_handling.py
+++ b/CorpusBuilderApp/tests/integration/test_error_handling.py
@@ -1,7 +1,10 @@
 # tests/test_error_handling.py
 import pytest
 import asyncio
-import aiohttp
+try:
+    import aiohttp
+except ImportError:  # pragma: no cover - optional
+    aiohttp = None
 import requests
 from unittest.mock import Mock, patch, AsyncMock
 import tempfile

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,37 @@ import tempfile
 import shutil
 import pytest
 
+# Ensure repo root is importable when running tests individually
+base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if base_dir not in sys.path:
+    sys.path.insert(0, base_dir)
+
+# Alias for legacy package name used by some tests
+sys.modules.setdefault(
+    "CryptoFinanceCorpusBuilder",
+    types.ModuleType("CryptoFinanceCorpusBuilder"),
+)
+sys.modules.setdefault(
+    "CryptoFinanceCorpusBuilder.shared_tools",
+    __import__("CorpusBuilderApp.shared_tools", fromlist=["dummy"]),
+)
+
+try:
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    def load_dotenv(*args, **kwargs):
+        pass
+    stub = types.ModuleType("dotenv")
+    stub.load_dotenv = load_dotenv
+    sys.modules.setdefault("dotenv", stub)
+
 # Ensure the CorpusBuilderApp root is on the Python path
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'CorpusBuilderApp'))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-if 'PySide6' not in sys.modules:
+if os.environ.get("PYTEST_QT_STUBS") == "1":
+    print("Loaded PySide6 stub")
     class _Signal:
         def __init__(self, *a, **k):
             self._slots = []
@@ -75,6 +100,34 @@ if 'PySide6' not in sys.modules:
     class QGroupBox(QWidget):
         def __init__(self, *a, **k):
             pass
+    class QFrame(QWidget):
+        pass
+    class QLineEdit(QWidget):
+        def text(self):
+            return ""
+        def setText(self, *a, **k):
+            pass
+    class QComboBox(QWidget):
+        def __init__(self, *a, **k):
+            self._text = ""
+        def addItem(self, *a, **k):
+            pass
+        def currentText(self):
+            return self._text
+        def setCurrentText(self, t):
+            self._text = t
+    class QGridLayout:
+        def addWidget(self, *a, **k):
+            pass
+    class QTextEdit(QWidget):
+        def toPlainText(self):
+            return ""
+        def setPlainText(self, *a, **k):
+            pass
+    class QTableWidget(QWidget):
+        pass
+    class QSplitter(QWidget):
+        pass
     class QSpinBox:
         def __init__(self, *a, **k):
             self._value = 0
@@ -145,6 +198,13 @@ if 'PySide6' not in sys.modules:
         QListWidget=QListWidget,
         QTreeView=QTreeView,
         QGroupBox=QGroupBox,
+        QFrame=QFrame,
+        QLineEdit=QLineEdit,
+        QComboBox=QComboBox,
+        QGridLayout=QGridLayout,
+        QTextEdit=QTextEdit,
+        QTableWidget=QTableWidget,
+        QSplitter=QSplitter,
         QFileDialog=QFileDialog,
         QMessageBox=QMessageBox,
         QSystemTrayIcon=QSystemTrayIcon,


### PR DESCRIPTION
## Summary
- update both conftest files with PYTHONPATH fix and dotenv fallback
- alias `CryptoFinanceCorpusBuilder` for legacy imports
- add optional PySide6 stubs gated by `PYTEST_QT_STUBS`
- extend qt stubs with extra widget classes
- guard aiohttp import in integration test

## Testing
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68473a32e628832680006d5c70d82ba9