### PR TITLE
Implement logs tab backend wiring

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/logs_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/logs_tab.py
@@ -19,6 +19,8 @@ from PySide6.QtGui import QColor, QTextCharFormat, QBrush
 from app.ui.widgets.card_wrapper import CardWrapper
 from app.ui.widgets.section_header import SectionHeader
 from app.ui.widgets.status_dot import StatusDot
+from shared_tools.services.activity_log_service import ActivityLogService
+from shared_tools.utils.log_file_parser import LogFileParser
 
 import os
 import re
@@ -26,9 +28,11 @@ from datetime import datetime
 
 
 class LogsTab(QWidget):
-    def __init__(self, project_config, parent=None):
+    def __init__(self, project_config, activity_log_service: ActivityLogService | None = None, parent=None):
         super().__init__(parent)
         self.project_config = project_config
+        self.activity_log_service = activity_log_service
+        self.log_parser = LogFileParser()
         self.log_files = {}
         self.current_log = None
         self.update_timer = None
@@ -64,6 +68,13 @@ class LogsTab(QWidget):
         self.level_filter.addItems(["All", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
         self.level_filter.currentIndexChanged.connect(self.apply_filters)
         controls_layout.addWidget(self.level_filter)
+
+        # Module/component filter
+        controls_layout.addWidget(QLabel("Module:"))
+        self.module_filter = QComboBox()
+        self.module_filter.addItem("All")
+        self.module_filter.currentIndexChanged.connect(self.apply_filters)
+        controls_layout.addWidget(self.module_filter)
         
         # Date range (simplified for now)
         self.today_only = QCheckBox("Today Only")
@@ -135,19 +146,26 @@ class LogsTab(QWidget):
     
     def scan_log_directory(self):
         """Scan for log files in the configured log directory"""
-        # In a real implementation, this would use project_config to get the log directory
-        # For now, use a placeholder path
         log_dir = self.project_config.get_logs_dir()
-        
-        # Placeholder - in a real implementation this would scan the actual directory
-        # For demonstration, populate with sample log files
-        self.log_files = {
-            "collectors.log": {"path": f"{log_dir}/collectors.log", "type": "collector"},
-            "processors.log": {"path": f"{log_dir}/processors.log", "type": "processor"},
-            "app.log": {"path": f"{log_dir}/app.log", "type": "app"},
-            "errors.log": {"path": f"{log_dir}/errors.log", "type": "error"}
-        }
-        
+        self.log_files = {}
+
+        if os.path.isdir(log_dir):
+            for name in sorted(os.listdir(log_dir)):
+                if not name.lower().endswith((".log", ".txt")):
+                    continue
+                path = os.path.join(log_dir, name)
+                log_type = "app"
+                if name.startswith("collector"):
+                    log_type = "collector"
+                elif name.startswith("processor"):
+                    log_type = "processor"
+                elif "error" in name:
+                    log_type = "error"
+                self.log_files[name] = {"path": path, "type": log_type}
+
+        if self.activity_log_service:
+            self.activity_log_service.log("LogsTab", f"Found {len(self.log_files)} log files")
+
         # Update the log selector
         self.log_selector.clear()
         for log_name in self.log_files:
@@ -167,22 +185,35 @@ class LogsTab(QWidget):
     def refresh_logs(self):
         """Refresh the current log view"""
         if not self.current_log:
-            print("DEBUG: No current log set, skipping refresh")
             return
-            
-        # Generate sample logs (ensure it returns a list, not None)
-        log_entries = self.generate_sample_logs(self.current_log.get("type", "app"))
-        
-        # Defensive check
-        if log_entries is None:
-            print("DEBUG: generate_sample_logs returned None, using empty list")
-            log_entries = []
-        
-        # Apply filters
+
+        path = self.current_log.get("path")
+        log_entries = self.log_parser.parse_file(path)
+        self.log_entries = log_entries
+        self.update_module_filter(log_entries)
+
         filtered_entries = self.filter_log_entries(log_entries)
-        
-        # Update the table
+        self.filtered_entries = filtered_entries
         self.populate_log_table(filtered_entries)
+
+        if self.activity_log_service:
+            self.activity_log_service.log(
+                "LogsTab",
+                f"Loaded {len(log_entries)} entries from {os.path.basename(path)}",
+            )
+
+    def update_module_filter(self, entries):
+        modules = sorted({e.get("component", "") for e in entries if e.get("component")})
+        current = self.module_filter.currentText()
+        self.module_filter.blockSignals(True)
+        self.module_filter.clear()
+        self.module_filter.addItem("All")
+        for m in modules:
+            self.module_filter.addItem(m)
+        index = self.module_filter.findText(current)
+        if index >= 0:
+            self.module_filter.setCurrentIndex(index)
+        self.module_filter.blockSignals(False)
     
     def generate_sample_logs(self, log_type):
         """Generate sample log entries for demonstration"""
@@ -355,18 +386,11 @@ class LogsTab(QWidget):
 
     def apply_filters(self):
         """Apply all current filters to the log entries."""
-        if not self.current_log:
+        if not hasattr(self, "log_entries"):
             return
-        # Get current filter values
-        level_filter = self.level_filter.currentText()
-        # component_filter is not present in your UI, so skip it
-        text_filter = self.filter_input.text()
-        # Generate new sample data (in real implementation, this would filter existing data)
-        log_entries = self.generate_sample_logs(self.current_log["type"])
-        # Apply filters
-        filtered_entries = self.filter_log_entries(log_entries)
-        self.filtered_entries = filtered_entries  # <-- Ensure this is set for export
-        # Update the table
+
+        filtered_entries = self.filter_log_entries(self.log_entries)
+        self.filtered_entries = filtered_entries
         self.populate_log_table(filtered_entries)
 
     def filter_log_entries(self, entries):
@@ -379,18 +403,30 @@ class LogsTab(QWidget):
         if not isinstance(entries, list):
             print(f"DEBUG: filter_log_entries received {type(entries)}, converting to list")
             entries = list(entries) if entries else []
-        
+
         level_filter = self.level_filter.currentText()
+        module_filter = self.module_filter.currentText()
         text_filter = self.filter_input.text().lower()
-        
+        today_only = self.today_only.isChecked()
+
         filtered = []
         for entry in entries:
             # Level filter
             if level_filter != "All" and entry.get("level") != level_filter:
                 continue
+            # Module filter
+            if module_filter != "All" and entry.get("component") != module_filter:
+                continue
             # Text filter
             if text_filter and text_filter not in entry.get("message", "").lower():
                 continue
+            if today_only:
+                try:
+                    entry_date = datetime.strptime(entry.get("time", ""), "%Y-%m-%d %H:%M:%S").date()
+                    if entry_date != datetime.now().date():
+                        continue
+                except Exception:
+                    pass
             filtered.append(entry)
         
         return filtered
@@ -439,9 +475,8 @@ class LogsTab(QWidget):
         """Clear all filters and show all log entries."""
         # Reset filter controls
         self.level_filter.setCurrentText("All")
-        # If you have a component_filter, reset it too
-        if hasattr(self, 'component_filter'):
-            self.component_filter.setCurrentText("All")
+        if hasattr(self, 'module_filter'):
+            self.module_filter.setCurrentText("All")
         self.filter_input.clear()
         # Clear the today only checkbox if you have one
         if hasattr(self, 'today_only'):
@@ -464,6 +499,10 @@ class LogsTab(QWidget):
         """Clear the current log view"""
         self.log_table.setRowCount(0)
         self.log_detail.clear()
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self.refresh_logs()
 
     def export_logs(self):
         """Export filtered log entries to a file"""

--- a/CorpusBuilderApp/shared_tools/utils/log_file_parser.py
+++ b/CorpusBuilderApp/shared_tools/utils/log_file_parser.py
@@ -1,0 +1,69 @@
+"""Simple log file parser utility."""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime
+from typing import List, Dict
+
+
+class LogFileParser:
+    """Parse log files into ``dict`` entries."""
+
+    PATTERNS = [
+        # [2023-12-01 10:30:45] INFO [Component] Message
+        r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\]\s+(\w+)\s+\[([^\]]+)\]\s+(.*)",
+        # 2023-12-01 10:30:45 - INFO - Component - Message
+        r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\s+-\s+(\w+)\s+-\s+([^\s]+)\s+-\s+(.*)",
+        # INFO:Component:Message
+        r"(\w+):([^:]+):(.*)",
+    ]
+
+    def parse_file(self, file_path: str) -> List[Dict[str, str]]:
+        """Parse a log file and return list of log entries."""
+        if not os.path.exists(file_path):
+            return []
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as fh:
+            lines = fh.readlines()
+        return self.parse_lines(lines)
+
+    def parse_lines(self, lines: List[str]) -> List[Dict[str, str]]:
+        entries: List[Dict[str, str]] = []
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            entry = self._parse_line(line)
+            if entry:
+                entries.append(entry)
+        return entries
+
+    def _parse_line(self, line: str) -> Dict[str, str] | None:
+        for pattern in self.PATTERNS:
+            match = re.match(pattern, line)
+            if match:
+                groups = match.groups()
+                if len(groups) == 4:
+                    timestamp, level, component, message = groups
+                elif len(groups) == 3:
+                    level, component, message = groups
+                    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                else:
+                    continue
+                return {
+                    "time": timestamp,
+                    "level": level,
+                    "component": component,
+                    "message": message,
+                    "details": "",
+                }
+        # Fallback for unmatched lines
+        return {
+            "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "level": "INFO",
+            "component": "Unknown",
+            "message": line,
+            "details": "",
+        }
+


### PR DESCRIPTION
## Summary
- add `LogFileParser` util for parsing simple log files
- wire up `LogsTab` to load real logs
- add severity and module filtering
- refresh log view on activation and manual reload

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68473fef9bc883268318830cee466aac