### PR TITLE
Use corpus stats in analytics

### DIFF
--- a/CorpusBuilderApp/shared_tools/services/corpus_stats_service.py
+++ b/CorpusBuilderApp/shared_tools/services/corpus_stats_service.py
@@ -59,7 +59,7 @@ class CorpusStatsService(QObject):
 
         if stats:
             self.stats = stats
-            self.stats_updated.emit(stats)
+        self.stats_updated.emit(stats)
 
     # ------------------------------------------------------------------
     def get_domain_summary(self) -> Dict[str, int]:
@@ -78,4 +78,22 @@ class CorpusStatsService(QObject):
                 else:
                     count = int(data) if isinstance(data, (int, float)) else 0
                 summary[domain] = count
+        return summary
+
+    # ------------------------------------------------------------------
+    def get_domain_size_summary(self) -> Dict[str, float]:
+        """Return mapping of domain name to size in MB."""
+        domains = self.stats.get("domains", {}) if isinstance(self.stats, dict) else {}
+        summary: Dict[str, float] = {}
+        if isinstance(domains, dict):
+            for domain, data in domains.items():
+                if isinstance(data, dict):
+                    size = (
+                        data.get("size_mb")
+                        or data.get("total_size_mb")
+                        or 0
+                    )
+                else:
+                    size = float(data) if isinstance(data, (int, float)) else 0.0
+                summary[domain] = float(size)
         return summary

--- a/CorpusBuilderApp/tests/unit/test_corpus_stats_service.py
+++ b/CorpusBuilderApp/tests/unit/test_corpus_stats_service.py
@@ -31,3 +31,15 @@ def test_refresh_stats(tmp_path):
 
     assert service.stats == stats
     service.stats_updated.emit.assert_called_once_with(stats)
+
+
+def test_get_domain_size_summary():
+    service = CorpusStatsService.__new__(CorpusStatsService)
+    service.stats = {
+        "domains": {
+            "A": {"size_mb": 1.2, "pdf_files": 2},
+            "B": {"total_size_mb": 3.4, "pdf_files": 1},
+        }
+    }
+    summary = service.get_domain_size_summary()
+    assert summary == {"A": 1.2, "B": 3.4}


### PR DESCRIPTION
## Summary
- update CorpusStatsService with a method for domain sizes
- switch AnalyticsTab charts to load real stats from CorpusStatsService
- refresh charts when stats change
- add tests for domain size summary

## Testing
- `PYTEST_QT_STUBS=1 pytest CorpusBuilderApp/tests/unit/test_corpus_stats_service.py -q`
- `PYTEST_QT_STUBS=1 pytest -q` *(fails: ModuleNotFoundError: pandas, QMenu, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684740021ac883268d44806d6d3f4f25