### PR TITLE
Update docs for test stubs

### DIFF
--- a/CorpusBuilderApp/docs/DEVELOPER_GUIDE.md
+++ b/CorpusBuilderApp/docs/DEVELOPER_GUIDE.md
@@ -64,7 +64,11 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for diagrams and data flow.
 
 - Unit tests: `pytest tests/unit/`
 - Integration tests: `pytest tests/integration/`
- - UI tests: `pytest tests/ui/ --qt-api pyside6`
+- Set `PYTEST_QT_STUBS=1` to run tests without PySide6 installed. This uses
+  stubbed Qt classes for headless or CI runs and covers only limited
+  functionality.
+- UI tests: `pytest tests/ui/ --qt-api pyside6`
+  *(should be run locally with PySide6 installed)*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # codex_try
 
 [![Tests](https://github.com/OWNER/REPO/actions/workflows/test.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/test.yml)
+
+## Testing
+
+The test suite can run without PySide6 installed by setting the environment
+variable `PYTEST_QT_STUBS=1`. This enables stubbed Qt classes so tests work in
+headless or CI environments. Only limited behaviour is covered, so full UI
+tests should still be executed locally with PySide6 available.


### PR DESCRIPTION
## Summary
- document how to run tests with PySide6 stubs

## Testing
- `PYTEST_QT_STUBS=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6847409d8830832698302eedaaf0932a