### PR TITLE
Add ActivityLogService integration

### DIFF
--- a/CorpusBuilderApp/tests/conftest.py
+++ b/CorpusBuilderApp/tests/conftest.py
@@ -39,57 +39,67 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
         def emit(self, *a, **k):
             pass
 
-    qtcore = types.SimpleNamespace(
-        QObject=object,
-        Signal=lambda *a, **k: _DummySignal(),
-        QThread=object,
-        QTimer=object,
-        Slot=lambda *a, **k: lambda *a, **k: None,
-        QDir=object,
-        Property=object,
-        __version__="6.5.0",
-        qVersion=lambda: "6.5.0",
-        qDebug=lambda *a, **k: None,
-        qWarning=lambda *a, **k: None,
-        qCritical=lambda *a, **k: None,
-        qFatal=lambda *a, **k: None,
-        qInfo=lambda *a, **k: None,
-        qInstallMessageHandler=lambda *a, **k: None,
-    )
+    class _DummyModuleCore(types.ModuleType):
+        def __getattr__(self, name):
+            return object
 
-    qtwidgets = types.SimpleNamespace(
-        QApplication=type("QApplication", (), {
+    qtcore = _DummyModuleCore("PySide6.QtCore")
+    class _QObject:
+        def __init__(self, *a, **k):
+            pass
+
+    qtcore.QObject = _QObject
+    qtcore.Signal = lambda *a, **k: _DummySignal()
+    qtcore.QThread = object
+    qtcore.QTimer = object
+    qtcore.Slot = lambda *a, **k: (lambda *a, **k: None)
+    qtcore.QDir = object
+    qtcore.Property = object
+    qtcore.Qt = types.SimpleNamespace(
+        Orientation=types.SimpleNamespace(Vertical=0, Horizontal=1),
+        AlignmentFlag=types.SimpleNamespace(AlignCenter=0),
+    )
+    qtcore.__version__ = "6.5.0"
+    qtcore.qVersion = lambda: "6.5.0"
+    qtcore.qDebug = lambda *a, **k: None
+    qtcore.qWarning = lambda *a, **k: None
+    qtcore.qCritical = lambda *a, **k: None
+    qtcore.qFatal = lambda *a, **k: None
+    qtcore.qInfo = lambda *a, **k: None
+    qtcore.qInstallMessageHandler = lambda *a, **k: None
+
+    class _DummyModuleWidgets(types.ModuleType):
+        def __getattr__(self, name):
+            return object
+
+    qtwidgets = _DummyModuleWidgets("PySide6.QtWidgets")
+    class _QWidget:
+        def __init__(self, *a, **k):
+            pass
+
+    qtwidgets.QWidget = _QWidget
+    qtwidgets.QApplication = type(
+        "QApplication",
+        (),
+        {
             "instance": staticmethod(lambda: None),
             "__init__": lambda self, *a, **k: None,
-            "quit": lambda self: None
-        }),
-        QWidget=object,
-        QVBoxLayout=object,
-        QHBoxLayout=object,
-        QTabWidget=object,
-        QLabel=object,
-        QProgressBar=object,
-        QPushButton=object,
-        QCheckBox=object,
-        QSpinBox=object,
-        QListWidget=object,
-        QTreeView=object,
-        QGroupBox=object,
-        QFrame=object,
-        QLineEdit=object,
-        QComboBox=object,
-        QGridLayout=object,
-        QTextEdit=object,
-        QTableWidget=object,
-        QSplitter=object,
-        QFileDialog=object,
-        QMessageBox=object,
-        QSystemTrayIcon=object,
+            "quit": lambda self: None,
+        },
     )
 
-    qtgui = types.SimpleNamespace(QIcon=object)
+    class _DummyGui(types.ModuleType):
+        def __getattr__(self, name):
+            return object
+
+    qtgui = _DummyGui("PySide6.QtGui")
+    qtgui.QIcon = object
     qttest = types.SimpleNamespace(QTest=object, QSignalSpy=object)
     qtmultimedia = types.SimpleNamespace(QSoundEffect=object)
+    class _DummyCharts(types.ModuleType):
+        def __getattr__(self, name):
+            return object
+    qtcharts = _DummyCharts("PySide6.QtCharts")
 
     sys.modules.setdefault("PySide6", types.SimpleNamespace(
         QtCore=qtcore,
@@ -102,6 +112,7 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
     sys.modules.setdefault("PySide6.QtGui", qtgui)
     sys.modules.setdefault("PySide6.QtTest", qttest)
     sys.modules.setdefault("PySide6.QtMultimedia", qtmultimedia)
+    sys.modules.setdefault("PySide6.QtCharts", qtcharts)
 
 # Mock external modules
 for mod in [
@@ -112,6 +123,7 @@ for mod in [
     "matplotlib",
     "matplotlib.pyplot",
     "seaborn",
+    "pandas",
 ]:
     sys.modules.setdefault(mod, types.ModuleType(mod))
 

--- a/CorpusBuilderApp/tests/ui/test_full_activity_tab.py
+++ b/CorpusBuilderApp/tests/ui/test_full_activity_tab.py
@@ -8,6 +8,15 @@ except Exception:  # pragma: no cover - PySide6 unavailable
 from app.ui.widgets.card_wrapper import CardWrapper
 from app.ui.widgets.section_header import SectionHeader
 from app.ui.widgets.status_dot import StatusDot
+from app.ui.tabs.full_activity_tab import FullActivityTab
+from shared_tools.services.activity_log_service import ActivityLogService
+
+@pytest.fixture
+def activity_tab(qapp, mock_project_config, qtbot):
+    service = ActivityLogService()
+    tab = FullActivityTab(mock_project_config, activity_log_service=service)
+    qtbot.addWidget(tab)
+    return tab, service
 
 
 def test_cardwrapper_title(qtbot):
@@ -37,4 +46,22 @@ def test_status_dot_styles(qtbot):
         widget = StatusDot(status, status)
         qtbot.addWidget(widget)
         assert widget.label.objectName() == obj_name
+
+
+def test_activity_table_updates(activity_tab, qtbot):
+    tab, service = activity_tab
+    initial = tab.activity_table.rowCount()
+    service.log(
+        "tester",
+        "New Task",
+        {
+            "status": "success",
+            "duration_seconds": 1,
+            "progress": 100,
+            "type": "Processing",
+            "domain": "Test",
+        },
+    )
+
+    qtbot.waitUntil(lambda: tab.activity_table.rowCount() == initial + 1, timeout=1000)
 


### PR DESCRIPTION
## Summary
- allow `FullActivityTab` to accept an `ActivityLogService`
- keep a persistent list of activities, loading from `project_config.get_logs_dir()`
- update charts and tables whenever a log entry is added
- expand Qt stubs for tests
- test that the table refreshes on log events

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -c /dev/null -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684740a6e71c8326a34a7707714efdda