### PR TITLE
Implement integration tests for collectors and config

### DIFF
--- a/CorpusBuilderApp/shared_tools/utils/extractor_utils.pyi
+++ b/CorpusBuilderApp/shared_tools/utils/extractor_utils.pyi
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union, Any
 
 try:
-    from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig  # type: ignore
+    from shared_tools.project_config import ProjectConfig  # type: ignore
 except ImportError:
     ProjectConfig = None
 

--- a/CorpusBuilderApp/tests/integration/test_multi_collector_flow.py
+++ b/CorpusBuilderApp/tests/integration/test_multi_collector_flow.py
@@ -1,12 +1,91 @@
-import pytest
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.fred_collector import FREDCollector
-from CryptoFinanceCorpusBuilder.shared_tools.collectors.github_collector import GitHubCollector
+import os
+import yaml
+from pathlib import Path
 
-@pytest.mark.skip("Audit stub – implement later")
+import pytest
+
+from shared_tools.project_config import ProjectConfig
+from shared_tools.storage.corpus_manager import CorpusManager
+
+
+def _write_yaml(path: Path, corpus_dir: Path) -> None:
+    data = {
+        "environment": "test",
+        "environments": {"test": {"corpus_dir": str(corpus_dir)}},
+    }
+    with open(path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh)
+
+
 def test_run_fred_and_github_collectors(monkeypatch, tmp_path):
     """Run collectors sequentially using mocked APIs."""
-    # TODO: create ProjectConfig pointing corpus_dir to tmp_path
-    # TODO: monkeypatch network calls for FREDCollector and GitHubCollector
-    # TODO: execute collectors and verify output files in corpus manager
-    pass
+
+    import sys, importlib
+    sys.modules.pop("numpy", None)
+    import numpy as _real_numpy
+    sys.modules["numpy"] = _real_numpy
+    from shared_tools.collectors.fred_collector import FREDCollector
+    from shared_tools.collectors.github_collector import GitHubCollector
+
+    corpus_root = tmp_path / "corpus"
+    cfg_path = tmp_path / "cfg.yaml"
+    _write_yaml(cfg_path, corpus_root)
+
+    # Use environment variables so directories resolve within tmp_path
+    monkeypatch.setenv("CORPUS_ROOT", str(corpus_root))
+    monkeypatch.setenv("RAW_DATA_DIR", str(corpus_root / "raw"))
+    monkeypatch.setenv("PROCESSED_DIR", str(corpus_root / "processed"))
+    monkeypatch.setenv("METADATA_DIR", str(corpus_root / "metadata"))
+    monkeypatch.setenv("LOGS_DIR", str(corpus_root / "logs"))
+
+    cfg = ProjectConfig.from_yaml(str(cfg_path))
+    # Provide attribute access used by collectors
+    cfg.raw_data_dir = cfg.get_raw_dir()
+    cfg.processed_dir = cfg.get_processed_dir()
+    cfg.metadata_dir = cfg.get_metadata_dir()
+    cfg.log_dir = cfg.get_logs_dir()
+    cfg.domain_configs = cfg.get("domains", {})
+
+    def fake_fred_api(self, endpoint, params=None):
+        if endpoint == "series":
+            return {"seriess": [{"series_id": params["series_id"], "info": {"title": "Fake"}}]}
+        if endpoint == "series/observations":
+            return {"observations": [{"date": "2024-01-01", "value": "1"}]}
+        return {}
+
+    def fake_github_api(self, endpoint, params=None):
+        if endpoint.startswith("search/repositories"):
+            return {
+                "items": [
+                    {
+                        "name": "fake-repo",
+                        "clone_url": "https://example.com/repo.git",
+                        "owner": {"login": "tester"},
+                    }
+                ]
+            }
+        return {}
+
+    def fake_clone(self, clone_url, target_dir):
+        target_dir.mkdir(parents=True, exist_ok=True)
+        (target_dir / "dummy.txt").write_text("ok")
+        return target_dir
+
+    monkeypatch.setattr(FREDCollector, "api_request", fake_fred_api)
+    monkeypatch.setattr(GitHubCollector, "api_request", fake_github_api)
+    monkeypatch.setattr(GitHubCollector, "_clone_repo", fake_clone)
+
+    fred = FREDCollector(cfg, api_key="token")
+    fred.collect(series_ids=["TEST"])
+
+    github = GitHubCollector(cfg, api_key="token")
+    github.collect(search_terms=["crypto"], max_repos=1)
+
+    cm = CorpusManager()
+    fred_files = list((cfg.raw_data_dir / "FRED").glob("*.json"))
+    repo_dirs = [p for p in (cfg.raw_data_dir / "Github").iterdir() if p.is_dir()]
+
+    assert fred_files, "FRED collector should output JSON files"
+    assert repo_dirs, "GitHub collector should clone at least one repo"
+    cm.validate_path(fred_files[0], must_exist=True)
+    cm.validate_path(repo_dirs[0], must_exist=True)

--- a/CorpusBuilderApp/tests/integration/test_project_config_edges.py
+++ b/CorpusBuilderApp/tests/integration/test_project_config_edges.py
@@ -1,20 +1,60 @@
-import pytest
-from CryptoFinanceCorpusBuilder.shared_tools.project_config import ProjectConfig
+import os
+from pathlib import Path
+import yaml
 
-@pytest.mark.skip("Audit stub – implement later")
+import pytest
+
+from shared_tools.project_config import ProjectConfig
+
+def _write_yaml(path: Path, corpus_dir: Path) -> None:
+    data = {
+        "environment": "test",
+        "environments": {"test": {"corpus_dir": str(corpus_dir)}},
+    }
+    with open(path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh)
+
+
 def test_load_minimal_config(tmp_path):
     """Load config with minimal fields and verify defaults."""
-    # TODO: write minimal YAML into tmp_path / 'config.yaml'
-    # TODO: invoke ProjectConfig on that file
-    # TODO: assert directories created and defaults applied
-    pass
+    corpus_root = tmp_path / "corpus"
+    cfg_path = tmp_path / "config.yaml"
+    _write_yaml(cfg_path, corpus_root)
 
-@pytest.mark.skip("Audit stub – implement later")
+    cfg = ProjectConfig.from_yaml(str(cfg_path))
+    cfg.raw_data_dir = cfg.get_raw_dir()
+    cfg.processed_dir = cfg.get_processed_dir()
+    cfg.metadata_dir = cfg.get_metadata_dir()
+    cfg.log_dir = cfg.get_logs_dir()
+
+    default_root = Path("~/crypto_corpus").expanduser()
+    assert cfg.get_corpus_root() == default_root
+    assert cfg.raw_data_dir == Path("~/crypto_corpus/raw").expanduser()
+    assert cfg.processed_dir == Path("~/crypto_corpus/processed").expanduser()
+
 def test_env_variable_override(monkeypatch, tmp_path):
     """Environment variables should override YAML paths."""
-    # TODO: set env vars like FRED_API_KEY
-    # TODO: load config and confirm overrides
-    pass
+
+    cfg_path = tmp_path / "config.yaml"
+    _write_yaml(cfg_path, tmp_path / "default")
+
+    corpus_root = tmp_path / "corpus"
+    monkeypatch.setenv("CORPUS_ROOT", str(corpus_root))
+    monkeypatch.setenv("RAW_DATA_DIR", str(corpus_root / "raw"))
+    monkeypatch.setenv("PROCESSED_DIR", str(corpus_root / "processed"))
+    monkeypatch.setenv("METADATA_DIR", str(corpus_root / "metadata"))
+    monkeypatch.setenv("LOGS_DIR", str(corpus_root / "logs"))
+    monkeypatch.setenv("FRED_API_KEY", "dummy")
+
+    cfg = ProjectConfig.from_yaml(str(cfg_path))
+    cfg.raw_data_dir = cfg.get_raw_dir()
+    cfg.processed_dir = cfg.get_processed_dir()
+    cfg.metadata_dir = cfg.get_metadata_dir()
+    cfg.log_dir = cfg.get_logs_dir()
+
+    assert cfg.get_corpus_root() == corpus_root
+    assert cfg.get_raw_dir() == corpus_root / "raw"
+    assert cfg.get("api_keys.fred_key") == "dummy"
 
 
 @pytest.mark.skip("Integration placeholder - configuration persistence")


### PR DESCRIPTION
## Summary
- update extractor_utils stub import
- rewrite integration tests for multi collector flow using shared_tools
- add integration tests for ProjectConfig edge cases

## Testing
- `PYTEST_QT_STUBS=1 pytest CorpusBuilderApp/tests/integration/test_multi_collector_flow.py::test_run_fred_and_github_collectors -q`
- `PYTEST_QT_STUBS=1 pytest CorpusBuilderApp/tests/integration/test_project_config_edges.py::test_load_minimal_config CorpusBuilderApp/tests/integration/test_project_config_edges.py::test_env_variable_override -q`


------
https://chatgpt.com/codex/tasks/task_e_684740a7c3288326a74af19f792c5234