### PR TITLE
Connect log service to activity widgets

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
@@ -55,12 +55,14 @@ class DashboardTab(QWidget):
         self.stats_service.refresh_stats()
 
         if self.activity_log_service:
-            try:
-                self.activity_log_service.activity_added.connect(
-                    self.recent_activity_widget.add_activity
+            self.activity_log_service.activity_added.connect(
+                self.recent_activity_widget.add_activity
+            )
+            self.activity_log_service.activity_added.connect(
+                lambda e: self.activity_log_widget.add_activity(
+                    e.get("source", "Info"), e.get("message", ""), e.get("details")
                 )
-            except Exception:
-                pass
+            )
 
     def _init_ui(self):
         self.setStyleSheet("QWidget, QFrame, QGroupBox { background-color: #0f1419; }")

--- a/CorpusBuilderApp/app/ui/widgets/recent_activity.py
+++ b/CorpusBuilderApp/app/ui/widgets/recent_activity.py
@@ -100,6 +100,32 @@ class RecentActivity(CardWrapper):
             child = self.activities_layout.takeAt(0)
             if child.widget():
                 child.widget().deleteLater()
+
+    def add_activity(self, activity_dict):
+        """Insert a single activity widget at the top of the list."""
+        if "time" not in activity_dict:
+            ts = activity_dict.get("timestamp")
+            try:
+                dt = datetime.fromisoformat(ts) if ts else None
+                time_str = dt.strftime("%H:%M") if dt else ""
+            except Exception:
+                time_str = ""
+            activity_dict = {
+                "time": time_str,
+                "action": activity_dict.get("message", ""),
+                "status": activity_dict.get("source", "info"),
+                "details": activity_dict.get("details", ""),
+            }
+
+        widget = self.create_activity_widget(activity_dict)
+
+        insert_index = self.activities_layout.count() - 1
+        if insert_index >= 0:
+            item = self.activities_layout.itemAt(insert_index)
+            if item and not item.widget():
+                self.activities_layout.insertWidget(insert_index, widget)
+                return
+        self.activities_layout.insertWidget(0, widget)
     
     def create_activity_widget(self, activity):
         """Create a compact widget for a single activity"""

--- a/CorpusBuilderApp/tests/unit/test_activity_log_service.py
+++ b/CorpusBuilderApp/tests/unit/test_activity_log_service.py
@@ -1,10 +1,34 @@
 import pytest
-from shared_tools.services.activity_log_service import ActivityLogService
 
 def test_log_records_and_emits(qapp):
+    from shared_tools.services.activity_log_service import ActivityLogService
     service = ActivityLogService()
     received = []
     service.activity_added.connect(lambda e: received.append(e))
     service.log("test", "message", {"a":1})
     assert received
     assert service.load_recent(1)[0] == received[0]
+
+
+def test_service_updates_recent_activity(qapp, mock_project_config):
+    # Provide missing Qt classes when running with stubs
+    from PySide6 import QtWidgets, QtCore
+    if not hasattr(QtWidgets, "QScrollArea"):
+        QtWidgets.QScrollArea = object
+    if getattr(QtCore, "QObject", None) is object:
+        class DummyQObject(object):
+            def __init__(self, *a, **k):
+                pass
+        QtCore.QObject = DummyQObject
+
+    from shared_tools.services.activity_log_service import ActivityLogService
+
+    service = ActivityLogService()
+
+    from app.ui.widgets.recent_activity import RecentActivity
+
+    widget = RecentActivity(mock_project_config)
+    before = widget.activities_layout.count()
+    service.activity_added.connect(widget.add_activity)
+    service.log("Test", "Something happened")
+    assert widget.activities_layout.count() == before + 1


### PR DESCRIPTION
## Summary
- add `add_activity` helper to RecentActivity widget
- connect ActivityLogService to RecentActivity and ActivityLog widgets
- test that ActivityLogService populates RecentActivity

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -o addopts='' -p no:cov CorpusBuilderApp/tests/unit/test_activity_log_service.py::test_service_updates_recent_activity -q -s`
- `QT_QPA_PLATFORM=offscreen pytest -o addopts='' -p no:cov CorpusBuilderApp/tests/unit/test_activity_log_service.py::test_log_records_and_emits -q -s`


------
https://chatgpt.com/codex/tasks/task_e_684740acaef88326981f9cb43ea7cd28