### PR TITLE
Add task history tracking service

### DIFF
--- a/CorpusBuilderApp/app/main_window.py
+++ b/CorpusBuilderApp/app/main_window.py
@@ -24,6 +24,7 @@ from ui.tabs.full_activity_tab import FullActivityTab
 from ui.dialogs.settings_dialog import SettingsDialog
 from shared_tools.ui_wrappers.processors.corpus_balancer_wrapper import CorpusBalancerWrapper
 from shared_tools.services.activity_log_service import ActivityLogService
+from shared_tools.services.task_history_service import TaskHistoryService
 from shared_tools.services.tab_audit_service import TabAuditService
 
 class CryptoCorpusMainWindow(QMainWindow):
@@ -43,6 +44,7 @@ class CryptoCorpusMainWindow(QMainWindow):
 
         # Services and wrappers
         self.activity_log_service = ActivityLogService()
+        self.task_history_service = TaskHistoryService()
         self.balancer_wrapper = CorpusBalancerWrapper(self.config)
         self.balancer_wrapper.balance_completed.connect(self.on_balance_completed)
         
@@ -388,7 +390,11 @@ class CryptoCorpusMainWindow(QMainWindow):
             
             # Create new Full Activity tab
             if not self.full_activity_tab:
-                self.full_activity_tab = FullActivityTab(self.config)
+                self.full_activity_tab = FullActivityTab(
+                    self.config,
+                    activity_log_service=self.activity_log_service,
+                    task_history_service=self.task_history_service,
+                )
             
             # Add the tab and switch to it
             tab_index = self.tab_widget.addTab(self.full_activity_tab, "📊 Full Activity")

--- a/CorpusBuilderApp/app/ui/tabs/full_activity_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/full_activity_tab.py
@@ -36,10 +36,14 @@ from app.ui.widgets.status_dot import StatusDot
 class FullActivityTab(QWidget):
     """Comprehensive activity monitoring tab with detailed statistics and metrics"""
 
-    def __init__(self, config, activity_log_service=None, parent=None):
+    retry_requested = pyqtSignal(str)
+    stop_requested = pyqtSignal(str)
+
+    def __init__(self, config, activity_log_service=None, task_history_service=None, parent=None):
         super().__init__(parent)
         self.config = config
         self.activity_log_service = activity_log_service
+        self.task_source = task_history_service
         self.logger = logging.getLogger(self.__class__.__name__)
 
         # Apply shared UI theme settings
@@ -51,6 +55,13 @@ class FullActivityTab(QWidget):
         # Initialize persistent activity data
         self.activities_data: list[dict] = []
         self.load_existing_history()
+
+        if self.task_source:
+            try:
+                self.task_source.task_added.connect(lambda _: self.load_activity_data())
+                self.task_source.task_updated.connect(lambda _: self.load_activity_data())
+            except Exception:
+                pass
 
         if self.activity_log_service:
             try:
@@ -406,8 +417,11 @@ class FullActivityTab(QWidget):
         self.activity_table.itemSelectionChanged.connect(self.on_activity_selected)
         
         self.activity_table.setStyleSheet("background-color: #1a1f2e; color: #f9fafb; border: 1px solid #2d3748; border-radius: 8px;")
-        
+
         table_layout.addWidget(self.activity_table)
+        self.no_activity_label = QLabel("No activity yet")
+        self.no_activity_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        table_layout.addWidget(self.no_activity_label)
         layout.addWidget(table_container, 2)  # 2/3 of space
         
         # Right: Task details panel
@@ -485,6 +499,7 @@ class FullActivityTab(QWidget):
         return {
             "time": datetime.fromisoformat(timestamp).strftime("%H:%M:%S"),
             "start_time": timestamp,
+            "id": details.get("task_id"),
             "action": entry.get("message", ""),
             "status": details.get("status", "info"),
             "details": details.get("details", ""),
@@ -669,7 +684,8 @@ class FullActivityTab(QWidget):
         activities = self.get_activity_data()
         
         self.activity_table.setRowCount(len(activities))
-        
+        self.no_activity_label.setVisible(len(activities) == 0)
+
         for row, activity in enumerate(activities):
             # Time
             time_item = QTableWidgetItem(activity['time'])
@@ -754,6 +770,25 @@ Progress: {activity.get('progress', 0)}%
     
     def get_activity_data(self):
         """Return current activity log entries."""
+        if self.task_source:
+            tasks = self.task_source.load_recent_tasks()
+            mapped = []
+            for t in tasks:
+                start = t.get("start_time", datetime.utcnow().isoformat())
+                mapped.append({
+                    "id": t.get("id"),
+                    "time": datetime.fromisoformat(start).strftime("%H:%M:%S"),
+                    "start_time": start,
+                    "action": t.get("name", ""),
+                    "status": t.get("status", "pending"),
+                    "details": t.get("details", ""),
+                    "duration_seconds": t.get("duration_seconds", 0),
+                    "progress": t.get("progress", 0),
+                    "type": t.get("type", "General"),
+                    "domain": t.get("domain", "General"),
+                    "error_message": t.get("error_message", ""),
+                })
+            return mapped
         return self.activities_data
     
     def retry_task(self):
@@ -786,6 +821,8 @@ Progress: {activity.get('progress', 0)}%
                     self.stop_btn.setEnabled(True)
                     
                     self.logger.info(f"Retried task: {activity['action']}")
+                    if activity.get('id'):
+                        self.retry_requested.emit(str(activity['id']))
     
     def stop_task(self):
         print("[DEBUG] Stop button clicked")
@@ -815,6 +852,8 @@ Progress: {activity.get('progress', 0)}%
                     self.retry_btn.setEnabled(True)  # Allow retry of stopped task
                     
                     self.logger.info(f"Stopped task: {activity['action']}")
+                    if activity.get('id'):
+                        self.stop_requested.emit(str(activity['id']))
     
     def view_task_logs(self):
         print("[DEBUG] View Logs button clicked")

--- a/CorpusBuilderApp/shared_tools/services/task_history_service.py
+++ b/CorpusBuilderApp/shared_tools/services/task_history_service.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional, Dict
+from PySide6.QtCore import QObject, Signal as pyqtSignal
+
+
+class TaskHistoryService(QObject):
+    """Simple service to record background task history."""
+
+    task_added = pyqtSignal(dict)
+    task_updated = pyqtSignal(dict)
+
+    def __init__(self, parent: Optional[QObject] = None) -> None:
+        super().__init__(parent)
+        self._tasks: Dict[str, dict] = {}
+
+    # ------------------------------------------------------------------
+    def add_task(self, task_id: str, info: dict) -> None:
+        """Register a new task and emit ``task_added``."""
+        entry = {
+            "id": task_id,
+            "name": info.get("name", task_id),
+            "status": info.get("status", "pending"),
+            "progress": info.get("progress", 0),
+            "start_time": info.get("start_time", datetime.utcnow().isoformat()),
+        }
+        entry.update(info)
+        self._tasks[task_id] = entry
+        self.task_added.emit(entry)
+
+    # ------------------------------------------------------------------
+    def update_task(self, task_id: str, **updates: object) -> None:
+        """Update an existing task and emit ``task_updated``."""
+        task = self._tasks.setdefault(
+            task_id,
+            {"id": task_id, "name": task_id, "status": "pending", "progress": 0, "start_time": datetime.utcnow().isoformat()},
+        )
+        task.update(updates)
+        if "end_time" not in task and task.get("status") in {"success", "error", "stopped"}:
+            task["end_time"] = datetime.utcnow().isoformat()
+        self.task_updated.emit(task)
+
+    # ------------------------------------------------------------------
+    def load_recent_tasks(self, n: int = 20) -> list[dict]:
+        """Return a list of the most recently added tasks."""
+        tasks = list(self._tasks.values())
+        tasks.sort(key=lambda t: t.get("start_time", ""))
+        return tasks[-n:]
+

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/base_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/base_wrapper.py
@@ -2,6 +2,9 @@ from PySide6.QtCore import QObject, Signal as pyqtSignal, QThread, QTimer
 from abc import ABC, abstractmethod
 import logging
 from typing import Dict, Any, Optional
+from uuid import uuid4
+
+from shared_tools.services.task_history_service import TaskHistoryService
 from pathlib import Path
 
 class BaseWorkerThread(QThread):
@@ -44,12 +47,15 @@ class BaseWrapper(QObject):
     error_occurred = pyqtSignal(str)    # Error message
     completed = pyqtSignal(dict)        # Results dictionary
     
-    def __init__(self, config):
+    def __init__(self, config, activity_log_service=None, task_history_service: TaskHistoryService | None = None):
         super().__init__()
         self.config = config
         self.worker = None
         self._is_running = False
         self.logger = logging.getLogger(f"{self.__class__.__name__}")
+        self.activity_log_service = activity_log_service
+        self.task_history_service = task_history_service
+        self._task_id: str | None = None
         
     @abstractmethod
     def _create_target_object(self):
@@ -66,9 +72,25 @@ class BaseWrapper(QObject):
         if self._is_running:
             self.status_updated.emit("Operation already in progress")
             return
-            
+
         self._is_running = True
         self.status_updated.emit("Starting operation...")
+
+        self._task_id = str(uuid4())
+        if self.task_history_service:
+            self.task_history_service.add_task(
+                self._task_id,
+                {"name": self.__class__.__name__, "status": "running", "progress": 0},
+            )
+        if self.activity_log_service:
+            try:
+                self.activity_log_service.log(
+                    self.__class__.__name__,
+                    "Task started",
+                    {"status": "running", "task_id": self._task_id},
+                )
+            except Exception:
+                pass
         
         target_obj = self._create_target_object()
         operation_type = self._get_operation_type()
@@ -84,6 +106,8 @@ class BaseWrapper(QObject):
         if total > 0:
             percentage = min(100, int((current / total) * 100))
             self.progress_updated.emit(percentage)
+            if self.task_history_service and self._task_id:
+                self.task_history_service.update_task(self._task_id, progress=percentage)
         if message:
             self.status_updated.emit(message)
             
@@ -92,12 +116,38 @@ class BaseWrapper(QObject):
         self._is_running = False
         self.error_occurred.emit(error_message)
         self.status_updated.emit(f"Error: {error_message}")
+        if self.task_history_service and self._task_id:
+            self.task_history_service.update_task(
+                self._task_id, status="error", error_message=error_message
+            )
+        if self.activity_log_service:
+            try:
+                self.activity_log_service.log(
+                    self.__class__.__name__,
+                    "Task error",
+                    {"status": "error", "task_id": self._task_id, "error_message": error_message},
+                )
+            except Exception:
+                pass
         
     def _on_finished(self, results: Dict[str, Any]):
         """Handle completion"""
         self._is_running = False
         self.completed.emit(results)
         self.status_updated.emit("Operation completed successfully")
+        if self.task_history_service and self._task_id:
+            self.task_history_service.update_task(
+                self._task_id, status="success", progress=100
+            )
+        if self.activity_log_service:
+            try:
+                self.activity_log_service.log(
+                    self.__class__.__name__,
+                    "Task completed",
+                    {"status": "success", "task_id": self._task_id},
+                )
+            except Exception:
+                pass
         
     def stop(self):
         """Stop the operation"""
@@ -106,6 +156,8 @@ class BaseWrapper(QObject):
             self.worker.wait()
             self._is_running = False
             self.status_updated.emit("Operation stopped")
+        if self.task_history_service and self._task_id:
+            self.task_history_service.update_task(self._task_id, status="stopped")
             
     def get_status(self) -> Dict[str, Any]:
         """Get current operation status"""

--- a/CorpusBuilderApp/tests/ui/test_full_activity_tab.py
+++ b/CorpusBuilderApp/tests/ui/test_full_activity_tab.py
@@ -9,12 +9,16 @@ from app.ui.widgets.card_wrapper import CardWrapper
 from app.ui.widgets.section_header import SectionHeader
 from app.ui.widgets.status_dot import StatusDot
 from app.ui.tabs.full_activity_tab import FullActivityTab
-from shared_tools.services.activity_log_service import ActivityLogService
+from shared_tools.services.task_history_service import TaskHistoryService
 
 @pytest.fixture
 def activity_tab(qapp, mock_project_config, qtbot):
-    service = ActivityLogService()
-    tab = FullActivityTab(mock_project_config, activity_log_service=service)
+    service = TaskHistoryService()
+    tab = FullActivityTab(
+        mock_project_config,
+        activity_log_service=None,
+        task_history_service=service,
+    )
     qtbot.addWidget(tab)
     return tab, service
 
@@ -51,17 +55,8 @@ def test_status_dot_styles(qtbot):
 def test_activity_table_updates(activity_tab, qtbot):
     tab, service = activity_tab
     initial = tab.activity_table.rowCount()
-    service.log(
-        "tester",
-        "New Task",
-        {
-            "status": "success",
-            "duration_seconds": 1,
-            "progress": 100,
-            "type": "Processing",
-            "domain": "Test",
-        },
-    )
+    service.add_task("t1", {"name": "New Task", "status": "running"})
+    service.update_task("t1", status="success", progress=100, duration_seconds=1)
 
     qtbot.waitUntil(lambda: tab.activity_table.rowCount() == initial + 1, timeout=1000)
 

--- a/CorpusBuilderApp/tests/unit/test_task_history_service.py
+++ b/CorpusBuilderApp/tests/unit/test_task_history_service.py
@@ -1,0 +1,18 @@
+import pytest
+
+from shared_tools.services.task_history_service import TaskHistoryService
+
+
+def test_add_and_update_task(qapp):
+    service = TaskHistoryService()
+    added = []
+    updated = []
+    service.task_added.connect(lambda t: added.append(t))
+    service.task_updated.connect(lambda t: updated.append(t))
+    service.add_task("t1", {"name": "Task"})
+    assert added and added[0]["name"] == "Task"
+    service.update_task("t1", status="running", progress=50)
+    assert updated and updated[0]["progress"] == 50
+    tasks = service.load_recent_tasks()
+    assert tasks[-1]["status"] == "running"
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,11 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
         pass
     class QSplitter(QWidget):
         pass
+    class QScrollArea(QWidget):
+        def setWidgetResizable(self, *a, **k):
+            pass
+        def setHorizontalScrollBarPolicy(self, *a, **k):
+            pass
     class QSpinBox:
         def __init__(self, *a, **k):
             self._value = 0
@@ -150,12 +155,59 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
             return types.SimpleNamespace(text=lambda: self._items[i], isSelected=lambda: True)
     class QTreeView(QWidget):
         pass
+    class QTableWidgetItem:
+        def __init__(self, *a, **k):
+            pass
+    class QDateEdit(QWidget):
+        def setDate(self, *a, **k):
+            pass
+        def setDisplayFormat(self, *a, **k):
+            pass
+        def setCalendarPopup(self, *a, **k):
+            pass
+    class QMenu(QWidget):
+        def addAction(self, *a, **k):
+            pass
     class QTabWidget(QWidget):
         def addTab(self, *a, **k):
             pass
     class QFileDialog: pass
     class QMessageBox: pass
     class QSystemTrayIcon:
+        def __init__(self, *a, **k):
+            pass
+    class QInputDialog(QWidget):
+        pass
+    class QSlider(QWidget):
+        pass
+    class QHeaderView(QWidget):
+        Stretch = 0
+        ResizeToContents = 1
+        def setSectionResizeMode(self, *a, **k):
+            pass
+    class QFont:
+        pass
+    class QSizePolicy:
+        Expanding = 0
+        Preferred = 1
+    class QFileSystemModel(QWidget):
+        pass
+    class QDate:
+        currentDate = staticmethod(lambda: None)
+        def addDays(self, *a):
+            return self
+    class QDialog(QWidget):
+        pass
+    class QColor:
+        def __init__(self, *a, **k):
+            pass
+    class QBrush:
+        def __init__(self, *a, **k):
+            pass
+    class QTextCharFormat:
+        def __init__(self, *a, **k):
+            pass
+    class QMargins:
         def __init__(self, *a, **k):
             pass
     class QUrl: pass
@@ -174,6 +226,8 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
         Slot=Slot,
         QMutex=object,
         QUrl=QUrl,
+        QDate=QDate,
+        QMargins=QMargins,
         qDebug=lambda *a, **k: None,
         qWarning=lambda *a, **k: None,
         qCritical=lambda *a, **k: None,
@@ -204,12 +258,29 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
         QGridLayout=QGridLayout,
         QTextEdit=QTextEdit,
         QTableWidget=QTableWidget,
+        QTableWidgetItem=QTableWidgetItem,
         QSplitter=QSplitter,
+        QScrollArea=QScrollArea,
         QFileDialog=QFileDialog,
         QMessageBox=QMessageBox,
         QSystemTrayIcon=QSystemTrayIcon,
+        QInputDialog=QInputDialog,
+        QSlider=QSlider,
+        QHeaderView=QHeaderView,
+        QSizePolicy=QSizePolicy,
+        QDateEdit=QDateEdit,
+        QMenu=QMenu,
+        QFileSystemModel=QFileSystemModel,
+        QDialog=QDialog,
     )
-    qtgui = types.SimpleNamespace(QIcon=object)
+    qtgui = types.SimpleNamespace(
+        QIcon=object,
+        QFont=QFont,
+        QSizePolicy=QSizePolicy,
+        QColor=QColor,
+        QTextCharFormat=QTextCharFormat,
+        QBrush=QBrush,
+    )
     qttest = types.SimpleNamespace(QTest=object)
     qtmultimedia = types.SimpleNamespace(QSoundEffect=object)
     sys.modules['PySide6'] = types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- add `TaskHistoryService` for recording background task activity
- integrate new service with `BaseWrapper` and `FullActivityTab`
- expose the service from `CryptoCorpusMainWindow`
- emit retry/stop signals from `FullActivityTab`
- update Qt test stubs and tests for new behaviour

## Testing
- `PYTEST_QT_STUBS=1 pytest -q` *(fails: ModuleNotFoundError: cannot import name 'QSortFilterProxyModel')*

------
https://chatgpt.com/codex/tasks/task_e_684747a885c8832687d288c77dc47b3c