### PR TITLE
Add ConfigurationTab signal test

### DIFF
--- a/tests/ui/test_configuration_tab.py
+++ b/tests/ui/test_configuration_tab.py
@@ -1,0 +1,49 @@
+import os
+import pytest
+
+try:
+    from PySide6.QtCore import Qt
+    from app.ui.tabs.configuration_tab import ConfigurationTab
+    from PySide6.QtWidgets import QMessageBox
+except Exception:  # pragma: no cover - PySide6 unavailable
+    pytest.skip("Qt bindings not available", allow_module_level=True)
+
+
+def _make_config(mock_project_config, tmp_path, invalid=False):
+    """Prepare mock project config with config_path and required methods."""
+    if invalid:
+        mock_project_config.config_path = tmp_path / "missing" / "config.yaml"
+    else:
+        path = tmp_path / "config.yaml"
+        mock_project_config.config_path = path
+    # ensure attributes exist
+    mock_project_config.set = lambda *a, **k: None
+    mock_project_config.save = lambda *a, **k: None
+    return mock_project_config
+
+
+@pytest.fixture
+def config_tab(qtbot, mock_project_config, tmp_path):
+    cfg = _make_config(mock_project_config, tmp_path)
+    tab = ConfigurationTab(cfg)
+    qtbot.addWidget(tab)
+    return tab
+
+
+def test_save_emits_signal(config_tab, qtbot):
+    with qtbot.waitSignal(config_tab.configuration_saved, timeout=1000):
+        qtbot.mouseClick(config_tab.save_btn, Qt.MouseButton.LeftButton)
+
+
+def test_invalid_path_shows_error(qtbot, mock_project_config, tmp_path, monkeypatch):
+    cfg = _make_config(mock_project_config, tmp_path, invalid=True)
+    errors = []
+
+    def fake_critical(self, title, msg):
+        errors.append(msg)
+
+    monkeypatch.setattr(QMessageBox, "critical", fake_critical)
+    tab = ConfigurationTab(cfg)
+    qtbot.addWidget(tab)
+    qtbot.mouseClick(tab.save_btn, Qt.MouseButton.LeftButton)
+    assert errors and "Failed to save configuration" in errors[0]


### PR DESCRIPTION
## Summary
- add a GUI test for `ConfigurationTab` that checks the configuration_saved signal and error handling

## Testing
- `PYTEST_QT_STUBS=1 pytest -q tests/wrappers/test_worker_threads.py tests/test_processors_tab_connections.py tests/ui/test_configuration_tab.py`

------
https://chatgpt.com/codex/tasks/task_e_6847498502d48326ac49a1410f3fe59a