### PR TITLE
Add pytest/coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+    */tests/*
+    */stubs/*
+    */generated/*

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+qt_api = pyqt5
+addopts = --strict-markers --cov=CorpusBuilderApp --cov=shared_tools


### PR DESCRIPTION
## Summary
- add root `pytest.ini` for Qt and coverage options
- configure coverage to ignore test stubs and generated files

## Testing
- `PYTEST_QT_STUBS=1 pytest` *(fails: ImportError: cannot import name 'QDateEdit' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68474990bd148326a72a2bfc81a04713