### PR TITLE
Improve CI with linting and coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,16 +22,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r CorpusBuilderApp/requirements.txt
+          pip install ruff pytest pytest-cov
+      - name: Lint
+        run: ruff check .
       - name: Run tests
-        working-directory: CorpusBuilderApp
+        env:
+          PYTEST_QT_STUBS: '1'
         run: |
-          if python - <<'PY'
-import importlib.util, sys
-sys.exit(0 if importlib.util.find_spec('coverage') else 1)
-PY
-          then
-            coverage run -m pytest -m "not skip"
-            coverage report
-          else
-            pytest -m "not skip"
-          fi
+          pytest -m "not skip" --cov=. --cov-report=xml --cov-report=term --cov-fail-under=95
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml


### PR DESCRIPTION
## Summary
- run `ruff` as a lint check
- execute `pytest` with coverage
- upload the coverage report
- enforce minimum coverage of 95%

## Testing
- `ruff check .` *(fails: SyntaxError in notebook)*
- `PYTEST_QT_STUBS=1 pytest -m "not skip" --cov=. --cov-report=term --cov-fail-under=95` *(fails: Required test coverage of 95% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_684749917dec8326ac861797d90daaa1