### PR TITLE
Add pre-push hook with lint + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,16 @@ The test suite can run without PySide6 installed by setting the environment
 variable `PYTEST_QT_STUBS=1`. This enables stubbed Qt classes so tests work in
 headless or CI environments. Only limited behaviour is covered, so full UI
 tests should still be executed locally with PySide6 available.
+
+## Pre-push hook
+
+A convenience script is provided at `scripts/pre_push.sh` to run linting and the
+unit tests before code is pushed. Install the hook by linking it into your local
+Git hooks directory:
+
+```bash
+ln -s ../../scripts/pre_push.sh .git/hooks/pre-push
+```
+
+The script will run `ruff` if it is installed, or fall back to `flake8`. It then
+executes `pytest`. The push will be blocked if any of these steps fail.

--- a/scripts/pre_push.sh
+++ b/scripts/pre_push.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Git pre-push hook to run lint and tests.
+set -euo pipefail
+
+# Run ruff if available, otherwise fall back to flake8
+if command -v ruff >/dev/null 2>&1; then
+    echo "Running ruff..."
+    ruff .
+elif command -v flake8 >/dev/null 2>&1; then
+    echo "Running flake8..."
+    flake8 .
+else
+    echo "Error: neither ruff nor flake8 is installed." >&2
+    exit 1
+fi
+
+# Run tests
+echo "Running pytest..."
+PYTEST_QT_STUBS=${PYTEST_QT_STUBS:-0} pytest


### PR DESCRIPTION
## Summary
- add a `scripts/pre_push.sh` helper that runs `ruff`/`flake8` and `pytest`
- document how to install the hook in the README

## Testing
- `ruff check $(git ls-files '*.py')` *(fails: various style errors)*
- `PYTEST_QT_STUBS=1 pytest -q tests` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_684749933e0083268e6c6d3b867d2162