### PR TITLE
Populate import config

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/configuration_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/configuration_tab.py
@@ -767,11 +767,85 @@ class ConfigurationTab(QWidget):
             
     def import_config_file(self, file_path: str):
         try:
-            with open(file_path, 'r') as f:
+            with open(file_path, "r") as f:
                 config = yaml.safe_load(f)
-            # Here you can merge or overwrite the current config
-            # For now, we'll just print the imported config
-            print("Imported config:", config)
-            # TODO: Update the UI with the new config
+
+            if not isinstance(config, dict):
+                raise ValueError("Config file did not contain a dictionary")
+
+            # Environment
+            env_cfg = config.get("environment", {})
+            if isinstance(env_cfg, dict):
+                self.env_selector.setCurrentText(env_cfg.get("active", "test"))
+                self.config_path.setText(env_cfg.get("config_path", self.config_path.text()))
+                self.python_path.setText(env_cfg.get("python_path", self.python_path.text()))
+                self.venv_path.setText(env_cfg.get("venv_path", self.venv_path.text()))
+                self.temp_dir.setText(env_cfg.get("temp_dir", self.temp_dir.text()))
+                if "auto_save" in env_cfg:
+                    self.auto_save.setChecked(bool(env_cfg.get("auto_save")))
+            elif isinstance(env_cfg, str):
+                self.env_selector.setCurrentText(env_cfg)
+
+            # API keys
+            api_cfg = config.get("api_keys", {})
+            if isinstance(api_cfg, dict):
+                self.github_token.setText(api_cfg.get("github_token", ""))
+                self.aa_cookie.setText(api_cfg.get("aa_cookie", ""))
+                self.fred_key.setText(api_cfg.get("fred_key", ""))
+                self.bitmex_key.setText(api_cfg.get("bitmex_key", ""))
+                self.bitmex_secret.setText(api_cfg.get("bitmex_secret", ""))
+                self.arxiv_email.setText(api_cfg.get("arxiv_email", ""))
+
+            # Directories
+            dir_cfg = config.get("directories", {})
+            if isinstance(dir_cfg, dict):
+                self.corpus_root.setText(dir_cfg.get("corpus_root", self.corpus_root.text()))
+                self.raw_data_dir.setText(dir_cfg.get("raw_data_dir", self.raw_data_dir.text()))
+                self.processed_dir.setText(dir_cfg.get("processed_dir", self.processed_dir.text()))
+                self.metadata_dir.setText(dir_cfg.get("metadata_dir", self.metadata_dir.text()))
+                self.logs_dir.setText(dir_cfg.get("logs_dir", self.logs_dir.text()))
+                if "create_missing" in dir_cfg:
+                    self.create_missing.setChecked(bool(dir_cfg.get("create_missing")))
+                if "relative_paths" in dir_cfg:
+                    self.relative_paths.setChecked(bool(dir_cfg.get("relative_paths")))
+                if "validate_paths" in dir_cfg:
+                    self.validate_paths.setChecked(bool(dir_cfg.get("validate_paths")))
+
+            # Processing
+            proc_cfg = config.get("processing", {})
+            pdf_cfg = proc_cfg.get("pdf", {}) if isinstance(proc_cfg, dict) else {}
+            if isinstance(pdf_cfg, dict):
+                if "enable_ocr" in pdf_cfg:
+                    self.enable_ocr.setChecked(bool(pdf_cfg.get("enable_ocr")))
+                if "threads" in pdf_cfg:
+                    self.pdf_threads.setValue(int(pdf_cfg.get("threads")))
+                if "enable_formula" in pdf_cfg:
+                    self.enable_formula.setChecked(bool(pdf_cfg.get("enable_formula")))
+                if "enable_tables" in pdf_cfg:
+                    self.enable_tables.setChecked(bool(pdf_cfg.get("enable_tables")))
+
+            text_cfg = proc_cfg.get("text", {}) if isinstance(proc_cfg, dict) else {}
+            if isinstance(text_cfg, dict):
+                if "threads" in text_cfg:
+                    self.text_threads.setValue(int(text_cfg.get("threads")))
+                if "enable_language" in text_cfg:
+                    self.enable_language.setChecked(bool(text_cfg.get("enable_language")))
+                if "min_quality" in text_cfg:
+                    self.min_quality.setValue(int(text_cfg.get("min_quality")))
+                if "enable_deduplication" in text_cfg:
+                    self.enable_deduplication.setChecked(bool(text_cfg.get("enable_deduplication")))
+
+            adv_cfg = proc_cfg.get("advanced", {}) if isinstance(proc_cfg, dict) else {}
+            if isinstance(adv_cfg, dict):
+                if "batch_size" in adv_cfg:
+                    self.batch_size.setValue(int(adv_cfg.get("batch_size")))
+                if "max_retries" in adv_cfg:
+                    self.max_retries.setValue(int(adv_cfg.get("max_retries")))
+                if "timeout" in adv_cfg:
+                    self.timeout.setValue(int(adv_cfg.get("timeout")))
+
+            # Notify others of imported configuration
+            self.configuration_saved.emit(config)
+
         except Exception as e:
             QMessageBox.critical(self, "Import Error", f"Failed to import config: {str(e)}")

--- a/tests/ui/test_configuration_tab.py
+++ b/tests/ui/test_configuration_tab.py
@@ -47,3 +47,32 @@ def test_invalid_path_shows_error(qtbot, mock_project_config, tmp_path, monkeypa
     qtbot.addWidget(tab)
     qtbot.mouseClick(tab.save_btn, Qt.MouseButton.LeftButton)
     assert errors and "Failed to save configuration" in errors[0]
+
+
+def test_import_config_populates_fields(tmp_path, qtbot, mock_project_config):
+    cfg = _make_config(mock_project_config, tmp_path)
+    tab = ConfigurationTab(cfg)
+    qtbot.addWidget(tab)
+
+    config_data = {
+        "environment": {
+            "active": "production",
+            "config_path": "cfg.yaml",
+            "python_path": "/usr/bin/python",
+        },
+        "api_keys": {"fred_key": "abc"},
+        "directories": {"corpus_root": "/data"},
+        "processing": {"pdf": {"enable_ocr": False}},
+    }
+    config_file = tmp_path / "import.yaml"
+    import yaml
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    with qtbot.waitSignal(tab.configuration_saved, timeout=1000):
+        tab.import_config_file(str(config_file))
+
+    assert tab.env_selector.currentText() == "production"
+    assert tab.config_path.text() == "cfg.yaml"
+    assert tab.fred_key.text() == "abc"
+    assert tab.corpus_root.text() == "/data"
+    assert not tab.enable_ocr.isChecked()


### PR DESCRIPTION
## Summary
- populate widgets when importing config files
- emit `configuration_saved` after import
- test import sets fields

## Testing
- `PYTEST_QT_STUBS=1 pytest -q CorpusBuilderApp/tests` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_6847b025859c8326ad43a3ba16bf69e3