### PR TITLE
Implement collector activation for imbalance

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -372,36 +372,30 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
         QMenu=QMenu,
         QDateEdit=QDateEdit,
         QSplitter=QSplitter,
-        QMenu=QMenu,
-        QScrollArea=QScrollArea,
-        QDateEdit=QDateEdit,
-        QTableWidgetItem=QTableWidgetItem,
         QInputDialog=QInputDialog,
         QSlider=QSlider,
         QFont=QFont,
         QSizePolicy=QSizePolicy,
-        QHeaderView=QHeaderView,
-        QFileSystemModel=QFileSystemModel,
         QFileDialog=QFileDialog,
         QMessageBox=QMessageBox,
         QSystemTrayIcon=QSystemTrayIcon,
-        QInputDialog=QInputDialog,
-        QSlider=QSlider,
-        QHeaderView=QHeaderView,
-        QSizePolicy=QSizePolicy,
-        QDateEdit=QDateEdit,
-        QMenu=QMenu,
-        QFileSystemModel=QFileSystemModel,
-        QDialog=QDialog,
     )
     class _QtGui(types.SimpleNamespace):
         def __getattr__(self, name):
             return object
 
-    qtgui = _QtGui(QIcon=object, QAction=object, QFont=object, QColor=object,
-                   QTextCharFormat=object, QBrush=object, QDragEnterEvent=object,
-                   QDropEvent=object)
+    qtgui = _QtGui(
+        QIcon=object,
+        QAction=object,
+        QFont=object,
+        QColor=object,
+        QTextCharFormat=object,
+        QBrush=object,
+        QDragEnterEvent=object,
+        QDropEvent=object,
+    )
     qttest = types.SimpleNamespace(QTest=object)
+    qtcharts = types.SimpleNamespace()
     qtmultimedia = types.SimpleNamespace(QSoundEffect=object)
     sys.modules['PySide6'] = types.SimpleNamespace(
         QtCore=qtcore,


### PR DESCRIPTION
## Summary
- activate collectors when corpus imbalance is detected
- test that collectors start when missing domains are found
- fix PySide stub duplication in tests

## Testing
- `PYTEST_QT_STUBS=1 pytest tests/unit/test_corpus_balancer_wrapper.py::test_collect_for_missing_domains_triggers_collectors -q`
- `PYTEST_QT_STUBS=1 pytest -q` *(fails: 'integration' not found in markers)*

------
https://chatgpt.com/codex/tasks/task_e_6847b028f744832696446e9e736f7943