### PR TITLE
Implement JSON export functionality

### DIFF
--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/monitor_progress_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/monitor_progress_wrapper.py
@@ -741,8 +741,30 @@ class MonitorProgressWrapper(BaseWrapper, ProcessorWrapperMixin):
                 
     def _export_history_json(self, filename: str):
         """Export history to JSON format"""
-        # TODO: Implement JSON export logic
-        pass
+        headers = [
+            "Task ID",
+            "Name",
+            "Status",
+            "Start Time",
+            "Duration",
+            "Result",
+            "Error",
+        ]
+
+        rows = []
+        for row in range(self.history_table.rowCount()):
+            row_data = {}
+            for col in range(self.history_table.columnCount()):
+                item = self.history_table.item(row, col)
+                value = item.text() if item else ""
+                if col < len(headers):
+                    row_data[headers[col]] = value
+                else:
+                    row_data[str(col)] = value
+            rows.append(row_data)
+
+        with open(filename, "w", encoding="utf-8") as f:
+            json.dump(rows, f, ensure_ascii=False, indent=2)
 
     def refresh_config(self):
         """Reload parameters from ``self.config``. Placeholder for future use."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -372,26 +372,13 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
         QMenu=QMenu,
         QDateEdit=QDateEdit,
         QSplitter=QSplitter,
-        QMenu=QMenu,
-        QScrollArea=QScrollArea,
-        QDateEdit=QDateEdit,
-        QTableWidgetItem=QTableWidgetItem,
         QInputDialog=QInputDialog,
         QSlider=QSlider,
         QFont=QFont,
         QSizePolicy=QSizePolicy,
-        QHeaderView=QHeaderView,
-        QFileSystemModel=QFileSystemModel,
         QFileDialog=QFileDialog,
         QMessageBox=QMessageBox,
         QSystemTrayIcon=QSystemTrayIcon,
-        QInputDialog=QInputDialog,
-        QSlider=QSlider,
-        QHeaderView=QHeaderView,
-        QSizePolicy=QSizePolicy,
-        QDateEdit=QDateEdit,
-        QMenu=QMenu,
-        QFileSystemModel=QFileSystemModel,
         QDialog=QDialog,
     )
     class _QtGui(types.SimpleNamespace):
@@ -403,6 +390,10 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
                    QDropEvent=object)
     qttest = types.SimpleNamespace(QTest=object)
     qtmultimedia = types.SimpleNamespace(QSoundEffect=object)
+    class _DummyCharts(types.ModuleType):
+        def __getattr__(self, name):
+            return object
+    qtcharts = _DummyCharts("PySide6.QtCharts")
     sys.modules['PySide6'] = types.SimpleNamespace(
         QtCore=qtcore,
         QtWidgets=qtwidgets,

--- a/tests/unit/test_export_history_json.py
+++ b/tests/unit/test_export_history_json.py
@@ -1,0 +1,68 @@
+import json
+import json
+import sys
+import types
+
+dummy_mod = types.ModuleType("shared_tools.processors.monitor_progress")
+
+class _DummyMonitor:
+    def configure(self, *a, **k):
+        pass
+
+dummy_mod.MonitorProgress = _DummyMonitor
+sys.modules.setdefault("shared_tools.processors.monitor_progress", dummy_mod)
+
+from CorpusBuilderApp.shared_tools.ui_wrappers.processors.monitor_progress_wrapper import (
+    MonitorProgressWrapper,
+)
+
+class DummyItem:
+    def __init__(self, text: str):
+        self._text = text
+
+    def text(self) -> str:
+        return self._text
+
+
+class DummyTable:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def rowCount(self):
+        return len(self._rows)
+
+    def columnCount(self):
+        return len(self._rows[0]) if self._rows else 0
+
+    def item(self, r, c):
+        return DummyItem(self._rows[r][c])
+
+
+def test_export_history_json(tmp_path):
+    rows = [[
+        "1",
+        "Task",
+        "completed",
+        "2024-01-01 00:00:00",
+        "1s",
+        "ok",
+        "",
+    ]]
+    wrapper = types.SimpleNamespace(history_table=DummyTable(rows))
+
+    out = tmp_path / "history.json"
+    MonitorProgressWrapper._export_history_json(wrapper, str(out))
+
+    exported = json.loads(out.read_text())
+    expected = [
+        {
+            "Task ID": "1",
+            "Name": "Task",
+            "Status": "completed",
+            "Start Time": "2024-01-01 00:00:00",
+            "Duration": "1s",
+            "Result": "ok",
+            "Error": "",
+        }
+    ]
+    assert exported == expected


### PR DESCRIPTION
## Summary
- support exporting monitoring history to JSON
- fix Qt stubs and add dummy charts module
- test JSON export behaviour

## Testing
- `PYTEST_QT_STUBS=1 pytest -q tests/unit tests/wrappers`

------
https://chatgpt.com/codex/tasks/task_e_6847b02817f88326b3e9afd777e2b678