### PR TITLE
Update drag-and-drop handlers

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
@@ -777,10 +777,28 @@ class CorpusManagerTab(QWidget):
         if event.mimeData().hasUrls():
             event.acceptProposedAction()
     def dropEvent(self, event):
+        dest_dir = self.path_input.text()
+        added = []
         for url in event.mimeData().urls():
             file_path = url.toLocalFile()
-            # Add file to file browser (implement as needed)
-            pass
+            if os.path.isfile(file_path):
+                dest = os.path.join(dest_dir, os.path.basename(file_path))
+                try:
+                    shutil.copy(file_path, dest)
+                    added.append(dest)
+                except Exception as exc:  # pragma: no cover - defensive
+                    QMessageBox.critical(self, "Copy Error", str(exc))
+
+        if added:
+            self.notification_manager.add_notification(
+                "files_dropped",
+                "Files Added",
+                f"Added {len(added)} file(s)",
+                "success",
+                auto_hide=True,
+            )
+            if self.sound_enabled:
+                Notifier.notify("Files Added", f"Added {len(added)} file(s)", level="success")
         self.refresh_file_view()
 
     def batch_copy_files(self):

--- a/CorpusBuilderApp/app/ui/widgets/file_browser.py
+++ b/CorpusBuilderApp/app/ui/widgets/file_browser.py
@@ -341,15 +341,22 @@ class FileBrowser(QWidget):
         """Handle drop event."""
         urls = event.mimeData().urls()
         file_paths = []
-        
+
         for url in urls:
             if url.isLocalFile():
                 file_paths.append(url.toLocalFile())
-                
+
         if file_paths:
+            # Navigate to the directory of the first dropped file so it appears
+            # in the view. This keeps navigation history consistent.
+            first = file_paths[0]
+            directory = first if os.path.isdir(first) else os.path.dirname(first)
+            if os.path.isdir(directory):
+                self.set_directory(directory)
+
             self.files_dropped.emit(file_paths)
             self.status_label.setText(f"Dropped {len(file_paths)} file(s)")
-            
+
         event.acceptProposedAction()
         
     def get_current_directory(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 qt_api = pyqt5
 addopts = --strict-markers --cov=CorpusBuilderApp --cov=shared_tools
+markers =
+    integration: integration tests
+    asyncio: tests using asyncio
+    performance: performance tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -361,7 +361,6 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
         QGridLayout=QGridLayout,
         QTextEdit=QTextEdit,
         QTableWidget=QTableWidget,
-        QTableWidgetItem=QTableWidgetItem,
         QTableView=QTableView,
         QHeaderView=QHeaderView,
         QStandardItemModel=QStandardItemModel,
@@ -372,37 +371,33 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
         QMenu=QMenu,
         QDateEdit=QDateEdit,
         QSplitter=QSplitter,
-        QMenu=QMenu,
-        QScrollArea=QScrollArea,
-        QDateEdit=QDateEdit,
         QTableWidgetItem=QTableWidgetItem,
         QInputDialog=QInputDialog,
         QSlider=QSlider,
         QFont=QFont,
         QSizePolicy=QSizePolicy,
-        QHeaderView=QHeaderView,
-        QFileSystemModel=QFileSystemModel,
         QFileDialog=QFileDialog,
         QMessageBox=QMessageBox,
         QSystemTrayIcon=QSystemTrayIcon,
-        QInputDialog=QInputDialog,
-        QSlider=QSlider,
-        QHeaderView=QHeaderView,
-        QSizePolicy=QSizePolicy,
-        QDateEdit=QDateEdit,
-        QMenu=QMenu,
-        QFileSystemModel=QFileSystemModel,
         QDialog=QDialog,
     )
     class _QtGui(types.SimpleNamespace):
         def __getattr__(self, name):
             return object
 
-    qtgui = _QtGui(QIcon=object, QAction=object, QFont=object, QColor=object,
-                   QTextCharFormat=object, QBrush=object, QDragEnterEvent=object,
-                   QDropEvent=object)
+    qtgui = _QtGui(
+        QIcon=object,
+        QAction=object,
+        QFont=object,
+        QColor=object,
+        QTextCharFormat=object,
+        QBrush=object,
+        QDragEnterEvent=object,
+        QDropEvent=object,
+    )
     qttest = types.SimpleNamespace(QTest=object)
     qtmultimedia = types.SimpleNamespace(QSoundEffect=object)
+    qtcharts = types.SimpleNamespace()
     sys.modules['PySide6'] = types.SimpleNamespace(
         QtCore=qtcore,
         QtWidgets=qtwidgets,


### PR DESCRIPTION
## Summary
- show dropped files in file browser
- copy dropped files to corpus manager directory and notify
- define pytest markers for integration, asyncio, performance
- fix PySide6 stubs for tests

## Testing
- `PYTEST_QT_STUBS=1 pytest -q` *(fails: ImportError: cannot import name 'set_key' from 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6847b02a08c483268bbaf981ef3e523f