### PR TITLE
Fix dynamic card style selector

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
@@ -756,13 +756,13 @@ class DashboardTab(QWidget):
     def create_card_with_styling(self, title, object_name):
         container = CardWrapper(title)
         container.setObjectName(object_name)
-        container.setStyleSheet("""
-            QFrame[objectName="stat-card"] {
+        container.setStyleSheet(f"""
+            QFrame[objectName="{object_name}"] {{
                 background-color: #1a1f2e;
                 border: 1px solid #2d3748;
                 border-radius: 12px;
                 padding: 20px;
-            }
+            }}
         """)
         return container
 


### PR DESCRIPTION
## Summary
- use the object name parameter for styling selectors in `create_card_with_styling`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'keyring' and others)*

------
https://chatgpt.com/codex/tasks/task_e_6847bb22c2488326b8afc017ac4af910