### PR TITLE
Fix newline at EOF

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/full_activity_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/full_activity_tab.py
@@ -1089,4 +1089,4 @@ Progress: {activity.get('progress', 0)}%
     def update_theme(self, theme_name):
         """Update theme for charts"""
         self.chart_manager.set_theme(theme_name)
-        self.load_activity_data()  # Refresh charts with new theme 
+        self.load_activity_data()  # Refresh charts with new theme


### PR DESCRIPTION
## Summary
- ensure `full_activity_tab.py` ends with a newline

## Testing
- `pytest -q -o addopts=''` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6847bb29269c832686458bd5a5707cd5