### PR TITLE
Refactor metric card creation

### DIFF
--- a/CorpusBuilderApp/app/helpers/ui_helpers.py
+++ b/CorpusBuilderApp/app/helpers/ui_helpers.py
@@ -1,0 +1,47 @@
+from PySide6.QtWidgets import QFrame, QVBoxLayout, QLabel
+from PySide6.QtCore import Qt
+
+
+def create_metric_card(title: str, value: str, color: str):
+    """Return a standardized metric card widget.
+
+    Parameters
+    ----------
+    title: str
+        Title displayed below the value.
+    value: str
+        Value shown in large font.
+    color: str
+        Hex color string for the value text.
+
+    Returns
+    -------
+    tuple[QFrame, QLabel]
+        The card widget and the value label so callers can update it later.
+    """
+    card = QFrame()
+    card.setObjectName("card")
+    card.setMinimumSize(200, 100)
+    card.setStyleSheet(
+        "background-color: #1a1f2e; border-radius: 12px; border: 1px solid #2d3748;"
+    )
+
+    layout = QVBoxLayout(card)
+    layout.setSpacing(8)
+    layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+    title_label = QLabel(title)
+    title_label.setStyleSheet(
+        "font-size: 14px; color: #C5C7C7; font-weight: 600;"
+    )
+    title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    layout.addWidget(title_label)
+
+    value_label = QLabel(str(value))
+    value_label.setStyleSheet(
+        f"font-size: 28px; color: {color}; font-weight: 700;"
+    )
+    value_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    layout.addWidget(value_label)
+
+    return card, value_label

--- a/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
@@ -24,6 +24,7 @@ from app.ui.widgets.domain_distribution import DomainDistribution
 from app.ui.widgets.active_operations import ActiveOperations
 from app.ui.widgets.recent_activity import RecentActivity
 from app.ui.widgets.activity_log import ActivityLog
+from app.helpers.ui_helpers import create_metric_card
 from app.ui.theme.theme_constants import (
     CARD_MARGIN,
     CARD_PADDING,
@@ -100,7 +101,11 @@ class DashboardTab(QWidget):
             {"value": "3", "label": "Running Ops", "unit": ""},
         ]
         for stat in stat_data:
-            card, _ = self.fix_metric_card_transparency(stat["label"], stat["value"], stat["unit"])
+            card, value_label = create_metric_card(stat["label"], stat["value"], "#32B8C6")
+            if stat.get("unit"):
+                value_label.setText(f"{stat['value']} {stat['unit']}")
+            self.metric_labels[stat["label"]] = value_label
+            card.setObjectName("stat-card")
             metrics_bar.addWidget(card)
         main_layout.addLayout(metrics_bar)
 
@@ -171,42 +176,6 @@ class DashboardTab(QWidget):
         dot.setStyleSheet('background-color: #22c55e; border-radius: 7px;')
         return dot
 
-    def fix_metric_card_transparency(self, title, value, unit=''):
-        metric_widget = QWidget()
-        metric_widget.setStyleSheet('background-color: transparent; border: none;')
-        metric_layout = QVBoxLayout(metric_widget)
-        metric_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        metric_layout.setSpacing(4)
-        metric_layout.setContentsMargins(16, 16, 16, 16)
-        
-        if unit:
-            value_unit_container = QWidget()
-            value_unit_container.setStyleSheet('background-color: transparent;')
-            value_unit_layout = QHBoxLayout(value_unit_container)
-            value_unit_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            value_unit_layout.setSpacing(4)
-            value_unit_layout.setContentsMargins(0, 0, 0, 0)
-            value_label = QLabel(str(value))
-            value_label.setStyleSheet('font-size: 28px; color: #32B8C6; font-weight: 700; background-color: transparent;')
-            unit_label = QLabel(unit)
-            unit_label.setStyleSheet('font-size: 16px; color: #C5C7C7; font-weight: 500; background-color: transparent; margin-top: 8px;')
-            value_unit_layout.addWidget(value_label)
-            value_unit_layout.addWidget(unit_label)
-            metric_layout.addWidget(value_unit_container)
-        else:
-            value_label = QLabel(str(value))
-            value_label.setStyleSheet('font-size: 28px; color: #32B8C6; font-weight: 700; text-align: center; background-color: transparent;')
-            value_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            metric_layout.addWidget(value_label)
-        
-        title_label = QLabel(title)
-        title_label.setStyleSheet('font-size: 14px; color: #C5C7C7; font-weight: 600; text-align: center; background-color: transparent;')
-        title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        metric_layout.addWidget(title_label)
-
-        # keep reference to update later
-        self.metric_labels[title] = value_label
-        return metric_widget, value_label
 
     def create_giant_pie_chart(self, domain_data):
         from PySide6.QtCharts import QChart, QChartView, QPieSeries

--- a/CorpusBuilderApp/app/ui/tabs/full_activity_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/full_activity_tab.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 import json
 from app.helpers.chart_manager import ChartManager
+from app.helpers.ui_helpers import create_metric_card
 from app.ui.theme.theme_constants import (
     DEFAULT_FONT_SIZE,
     CARD_MARGIN,
@@ -147,19 +148,27 @@ class FullActivityTab(QWidget):
         metrics_layout = QHBoxLayout()
         
         # Total Tasks Card
-        self.total_tasks_card = self.create_metric_card("Total Tasks", "156", "#32B8C6")
+        self.total_tasks_card, self.total_tasks_value = create_metric_card(
+            "Total Tasks", "156", "#32B8C6"
+        )
         metrics_layout.addWidget(self.total_tasks_card)
         
         # Success Rate Card  
-        self.success_rate_card = self.create_metric_card("Success Rate", "94.2%", STATUS_DOT_GREEN)
+        self.success_rate_card, self.success_rate_value = create_metric_card(
+            "Success Rate", "94.2%", STATUS_DOT_GREEN
+        )
         metrics_layout.addWidget(self.success_rate_card)
         
         # Average Runtime Card
-        self.avg_runtime_card = self.create_metric_card("Avg Runtime", "12m 34s", "#E68161")
+        self.avg_runtime_card, self.avg_runtime_value = create_metric_card(
+            "Avg Runtime", "12m 34s", "#E68161"
+        )
         metrics_layout.addWidget(self.avg_runtime_card)
         
         # Active Tasks Card
-        self.active_tasks_card = self.create_metric_card("Active Now", "3", "#32B8C6")
+        self.active_tasks_card, self.active_now_value = create_metric_card(
+            "Active Now", "3", "#32B8C6"
+        )
         metrics_layout.addWidget(self.active_tasks_card)
         
         layout.addLayout(metrics_layout)
@@ -362,33 +371,6 @@ class FullActivityTab(QWidget):
         
         return container
     
-    def create_metric_card(self, title, value, color):
-        """Create a metric card widget with centered content and bigger fonts"""
-        card = QFrame()
-        card.setObjectName("card")
-        card.setMinimumSize(200, 100)
-        card.setStyleSheet("background-color: #1a1f2e; border-radius: 12px; border: 1px solid #2d3748;")
-        
-        layout = QVBoxLayout(card)
-        layout.setSpacing(8)
-        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)  # Center the content
-        
-        # Title - centered and slightly bigger
-        title_label = QLabel(title)
-        title_label.setStyleSheet("font-size: 14px; color: #C5C7C7; font-weight: 600;")  # Increased from 12px to 14px, weight 500 to 600
-        title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)  # Center the title
-        layout.addWidget(title_label)
-        
-        # Value - centered and bigger
-        value_label = QLabel(value)
-        value_label.setStyleSheet(f"font-size: 28px; color: {color}; font-weight: 700;")  # Increased from 24px to 28px
-        value_label.setAlignment(Qt.AlignmentFlag.AlignCenter)  # Center the value
-        layout.addWidget(value_label)
-        
-        # Store reference for updates
-        setattr(self, f"{title.lower().replace(' ', '_')}_value", value_label)
-        
-        return card
     
     def create_activity_details(self):
         """Create the detailed activity section"""


### PR DESCRIPTION
## Summary
- add `create_metric_card` helper for consistent metrics
- use helper in `DashboardTab` and `FullActivityTab`
- drop the old metric card methods

## Testing
- `pytest` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_6847bb2590b48326bcf87d9be0a2d725