### PR TITLE
Log exceptions instead of suppressing

### DIFF
--- a/CorpusBuilderApp/shared_tools/collectors/enhanced_client.py
+++ b/CorpusBuilderApp/shared_tools/collectors/enhanced_client.py
@@ -8,6 +8,8 @@ from bs4 import BeautifulSoup
 import requests  # type: ignore
 from dotenv import load_dotenv
 import time
+import logging
+logger = logging.getLogger(__name__)
 from selenium.webdriver.common.by import By
 import undetected_chromedriver as uc  # type: ignore
 from selenium.webdriver.chrome.options import Options
@@ -588,8 +590,8 @@ class CookieAuthClient:
                     pdf_file = self._wait_for_pdf_download(download_dir)
                     if pdf_file:
                         print(f"[Selenium] PDF downloaded via fast-download-link: {pdf_file}")
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.exception("Unhandled exception in download via fast-link: %s", exc)
             if not pdf_file:
                 # Try iframe
                 try:
@@ -600,8 +602,8 @@ class CookieAuthClient:
                     pdf_file = self._wait_for_pdf_download(download_dir)
                     if pdf_file:
                         print(f"[Selenium] PDF downloaded via iframe: {pdf_file}")
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.exception("Unhandled exception in download via iframe: %s", exc)
             if not pdf_file:
                 # Try all <a> links with 'download' or '.pdf'
                 links = driver.find_elements(By.TAG_NAME, "a")

--- a/CorpusBuilderApp/shared_tools/processors/batch_text_extractor_enhanced_prerefactor.py
+++ b/CorpusBuilderApp/shared_tools/processors/batch_text_extractor_enhanced_prerefactor.py
@@ -930,8 +930,8 @@ def cleanup_worker_temp_dirs():
                 import shutil
                 shutil.rmtree(worker_dir, ignore_errors=True)
                 print(f"Cleaned up temp dir: {worker_dir}")
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.exception("Unhandled exception in cleanup_worker_temp_dirs: %s", exc)
     except Exception as e:
         print(f"Cleanup warning: {str(e)}") 
 

--- a/CorpusBuilderApp/shared_tools/processors/deduplicator.py
+++ b/CorpusBuilderApp/shared_tools/processors/deduplicator.py
@@ -3,6 +3,7 @@ import os
 import sys
 from pathlib import Path
 import logging
+logger = logging.getLogger(__name__)
 import hashlib
 import json
 import re
@@ -325,8 +326,8 @@ class Deduplicator:
                 with open(meta_path, 'r') as f:
                     metadata = json.load(f)
                     return metadata.get('title')
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.exception("Unhandled exception in _extract_title: %s", exc)
         
         # If no metadata or no title in metadata, use filename
         return file_path.stem


### PR DESCRIPTION
## Summary
- add `logger` to deduplicator and log metadata read failures
- log temp cleanup failures in batch text extractor
- log selenium fast-link/iframe download errors in collector

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6847bf1788bc832696ef020d7402e558