### PR TITLE
Add central logging setup

### DIFF
--- a/CorpusBuilderApp/app/main.py
+++ b/CorpusBuilderApp/app/main.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(current_dir))
 from main_window import CryptoCorpusMainWindow
 from shared_tools.project_config import ProjectConfig
 from app.helpers.theme_manager import ThemeManager
+from shared_tools.logging_config import setup_logging
 
 # Update theme config path to use the correct location
 THEME_CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'resources', 'styles', 'theme_config.json')
@@ -93,16 +94,9 @@ class CryptoCorpusApp(QApplication):
         log_dir.mkdir(parents=True, exist_ok=True)
         
         log_file = log_dir / 'app.log'
-        
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            handlers=[
-                logging.FileHandler(log_file),
-                logging.StreamHandler()
-            ]
-        )
-        
+
+        setup_logging(log_file=log_file)
+
         self.logger = logging.getLogger('CryptoCorpusApp')
     
     def load_environment(self):

--- a/CorpusBuilderApp/shared_tools/logging_config.py
+++ b/CorpusBuilderApp/shared_tools/logging_config.py
@@ -1,0 +1,23 @@
+import logging
+
+
+def setup_logging(level: int = logging.INFO, log_file: str | None = None) -> None:
+    """Configure basic logging for the application.
+
+    Parameters
+    ----------
+    level:
+        The minimum logging level to capture.
+    log_file:
+        Optional path to a log file. If provided, logs will be written to this
+        file in addition to the console.
+    """
+    handlers = [logging.StreamHandler()]
+    if log_file:
+        handlers.append(logging.FileHandler(log_file))
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=handlers,
+    )

--- a/cli/execute_from_config.py
+++ b/cli/execute_from_config.py
@@ -8,6 +8,7 @@ from shared_tools.ui_wrappers.wrapper_factory import (
     create_processor_wrapper,
 )
 from shared_tools.ui_wrappers.processors.corpus_balancer_wrapper import CorpusBalancerWrapper
+from shared_tools.logging_config import setup_logging
 
 
 logger = logging.getLogger(__name__)
@@ -95,7 +96,7 @@ def run_balancer(config: ProjectConfig, preview: bool = False):
 
 def main(argv: List[str] | None = None):
     args = parse_args(argv)
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    setup_logging()
     config = load_config(args.config)
 
     run_collect = args.run_all or args.collect


### PR DESCRIPTION
## Summary
- centralize logging configuration in `shared_tools.logging_config`
- use the new logging setup in `execute_from_config.py`
- reuse the central logging in the desktop `main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6847bf29c038832689ff37c6bf7d5823