### PR TITLE
Improve hashing and deduplication

### DIFF
--- a/CorpusBuilderApp/shared_tools/collectors/base_collector.py
+++ b/CorpusBuilderApp/shared_tools/collectors/base_collector.py
@@ -3,6 +3,8 @@ import os
 import logging
 import random
 import time
+import json
+import hashlib
 import requests
 from urllib.parse import urlparse
 from pathlib import Path
@@ -57,6 +59,17 @@ class BaseCollector:
         self._setup_domain_directories()
         self.output_dir = self.raw_data_dir
         self.session = requests.Session()
+
+        # Hash cache for optional deduplication
+        self.hash_cache_path = Path(getattr(config, 'get_metadata_dir', lambda: Path(config.metadata_dir))()) / 'seen_hashes.json'
+        self.hash_cache = {}
+        if self.hash_cache_path.exists():
+            try:
+                with open(self.hash_cache_path, 'r') as f:
+                    self.hash_cache = json.load(f)
+            except Exception as exc:  # pragma: no cover - non-critical load failure
+                self.logger.warning(f"Failed to load hash cache: {exc}")
+        self.skip_known_hashes = False
     
     def _setup_domain_directories(self):
         """Create domain-based directory structure based on config."""
@@ -136,21 +149,41 @@ class BaseCollector:
         # Download the file
         headers = {'User-Agent': self._get_random_user_agent()}
         
-        try:
-            self.logger.info(f"Downloading {url} to {filepath}")
-            response = requests.get(url, headers=headers, stream=True, timeout=30)
-            response.raise_for_status()
-            
-            with open(filepath, 'wb') as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    if chunk:
-                        f.write(chunk)
-            
-            self.logger.info(f"Successfully downloaded {filepath}")
-            return filepath
-        except Exception as e:
-            self.logger.error(f"Error downloading {url}: {e}")
-            return None
+        for attempt in range(3):
+            try:
+                self.logger.info(f"Downloading {url} to {filepath}")
+                response = requests.get(url, headers=headers, stream=True, timeout=30)
+                response.raise_for_status()
+
+                if int(response.headers.get("Content-Length", 0)) > 100_000_000:
+                    self.logger.warning(f"Large file: {filename}")
+
+                with open(filepath, 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+
+                sha256 = hashlib.sha256(filepath.read_bytes()).hexdigest()
+                self.logger.info(f"SHA256 for {filepath.name}: {sha256}")
+
+                if sha256 in self.hash_cache and self.skip_known_hashes:
+                    self.logger.info(f"Known file detected by hash: {filepath}")
+                    if filepath.exists():
+                        filepath.unlink()
+                    return None
+
+                if sha256 not in self.hash_cache:
+                    self.hash_cache[sha256] = str(filepath)
+                    self._save_hash_cache()
+
+                self.logger.info(f"Successfully downloaded {filepath}")
+                return filepath
+            except Exception as e:
+                if attempt == 2:
+                    self.logger.error(f"Download failed after 3 attempts: {e}")
+                    return None
+                self.logger.warning(f"Retry {attempt+1}/3 for {url}")
+                time.sleep(2)
     
     def _get_random_user_agent(self) -> str:
         """Return a random user agent string"""
@@ -162,3 +195,12 @@ class BaseCollector:
         delay = random.uniform(*self.delay_range)
         self.logger.debug(f"Waiting {delay:.2f}s before requesting from {domain}")
         time.sleep(delay)
+
+    def _save_hash_cache(self) -> None:
+        """Persist the global hash cache safely."""
+        try:
+            self.hash_cache_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.hash_cache_path, 'w') as f:
+                json.dump(self.hash_cache, f, indent=2)
+        except Exception as exc:  # pragma: no cover - non-critical save failure
+            self.logger.warning(f"Failed to update hash cache: {exc}")

--- a/tests/unit/test_base_collector_download.py
+++ b/tests/unit/test_base_collector_download.py
@@ -1,0 +1,56 @@
+import hashlib
+import json
+from types import SimpleNamespace
+import time
+
+import requests
+
+from shared_tools.collectors.base_collector import BaseCollector
+
+
+class DummyCollector(BaseCollector):
+    def collect(self, *a, **k):
+        pass
+
+
+def test_download_file_retries_and_hash(tmp_path, monkeypatch):
+    raw = tmp_path / "raw"
+    log_dir = tmp_path / "log"
+    meta_dir = tmp_path / "meta"
+    cfg = SimpleNamespace(
+        raw_data_dir=raw,
+        log_dir=log_dir,
+        metadata_dir=meta_dir,
+        domain_configs={},
+    )
+    cfg.get_metadata_dir = lambda: meta_dir
+    collector = DummyCollector(cfg)
+
+    attempts = {"count": 0}
+
+    class Resp:
+        def __init__(self, content=b"data"):
+            self.headers = {"Content-Length": str(len(content))}
+            self._content = content
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size=8192):
+            yield self._content
+
+    def fake_get(url, headers=None, stream=True, timeout=30):
+        attempts["count"] += 1
+        if attempts["count"] < 2:
+            raise requests.RequestException("fail")
+        return Resp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+
+    path = collector.download_file("http://example.com/file", "file.txt")
+    assert attempts["count"] == 2
+    assert path is not None
+    sha = hashlib.sha256(b"data").hexdigest()
+    cache = json.load(open(meta_dir / "seen_hashes.json"))
+    assert cache[sha] == str(path)

--- a/tests/unit/test_deduplicator_sha256.py
+++ b/tests/unit/test_deduplicator_sha256.py
@@ -1,0 +1,22 @@
+import json
+import hashlib
+from pathlib import Path
+
+from shared_tools.processors.deduplicator import Deduplicator
+
+
+def test_sha256_duplicate_detection(tmp_path):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    f1 = corpus / "a.txt"
+    f2 = corpus / "b.txt"
+    f1.write_text("one")
+    f2.write_text("two")
+    sha = hashlib.sha256(b"same").hexdigest()
+    for f in (f1, f2):
+        with open(Path(f"{f}.meta"), "w") as m:
+            json.dump({"sha256": sha, "title": "x"}, m)
+    d = Deduplicator(corpus_dir=corpus)
+    d.scan_corpus()
+    dups = d.find_duplicates()
+    assert any(g.get("hash") == sha for g in dups)

--- a/tests/unit/test_pdf_extractor_metadata.py
+++ b/tests/unit/test_pdf_extractor_metadata.py
@@ -1,0 +1,57 @@
+import hashlib
+import logging
+from pathlib import Path
+import sys
+import types
+
+# Stub heavy PDF libraries before importing PDFExtractor
+dummy = types.ModuleType("dummy")
+sys.modules.setdefault("PyPDF2", dummy)
+sys.modules.setdefault("fitz", dummy)
+camelot_mod = types.ModuleType("camelot")
+camelot_mod.read_pdf = lambda *a, **k: []
+sys.modules.setdefault("camelot", camelot_mod)
+pandas_mod = types.ModuleType("pandas")
+pandas_mod.DataFrame = object
+sys.modules.setdefault("pandas", pandas_mod)
+pdfminer_high = types.ModuleType("pdfminer.high_level")
+pdfminer_high.extract_text = lambda *a, **k: ""
+pdfminer_high.extract_pages = lambda *a, **k: []
+sys.modules.setdefault("pdfminer.high_level", pdfminer_high)
+pdfminer_layout = types.ModuleType("pdfminer.layout")
+pdfminer_layout.LTTextContainer = object
+pdfminer_layout.LTChar = object
+pdfminer_layout.LTFigure = object
+sys.modules.setdefault("pdfminer.layout", pdfminer_layout)
+
+from shared_tools.processors.pdf_extractor import PDFExtractor
+
+
+class DummyExtractor(PDFExtractor):
+    def __init__(self):
+        # bypass BaseExtractor
+        self.logger = logging.getLogger("dummy")
+
+    def extract_tables(self, file_path: Path):
+        return []
+
+    def extract_formulas(self, text: str):
+        return []
+
+    def _extract_with_pypdf2(self, fp: Path) -> str:
+        return "short"
+
+    def _extract_with_pymupdf(self, fp: Path) -> str:
+        return "this is longer text"
+
+    def _extract_with_pdfminer(self, fp: Path) -> str:
+        return ""
+
+
+def test_extract_text_adds_sha256_and_method(tmp_path):
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(b"content")
+    ext = DummyExtractor()
+    text, meta = ext.extract_text(pdf)
+    assert meta["sha256"] == hashlib.sha256(b"content").hexdigest()
+    assert meta["selected_text_method"] == "pymupdf"


### PR DESCRIPTION
## Summary
- compute SHA256 hash and preferred extraction method when processing PDFs
- add retry, hash logging and optional dedup skip to BaseCollector
- extend Deduplicator with SHA256 metadata indexing
- add regression tests for new features

## Testing
- `PYTEST_QT_STUBS=1 pytest tests/unit/test_pdf_extractor_metadata.py tests/unit/test_base_collector_download.py tests/unit/test_deduplicator_sha256.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d323e1148326a498621237f6ff0e