### PR TITLE
Add proprietary license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Copyright (c) 2024 Bored AI Labs
+
+All rights reserved.
+
+This software and associated files (the “Software”) are proprietary to Bored AI Labs.
+
+You may not:
+- Copy, modify, merge, publish, distribute, sublicense, or sell the Software or any derivative works
+- Use the Software in any commercial product, platform, or service
+- Host, serve, or otherwise expose the Software publicly or privately without written permission
+
+The Software is provided "as is" without warranty of any kind.
+
+To inquire about licensing, contact: legal@boredailabs.com
+

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ Launch the application with offscreen rendering:
 ```bash
 HEADLESS=1 python app/main.py
 ```
+
+## License
+
+This project is proprietary and all rights are reserved by Bored AI Labs.
+To inquire about licensing, contact [legal@boredailabs.com](mailto:legal@boredailabs.com).
+


### PR DESCRIPTION
## Summary
- add restrictive license file for Bored AI Labs
- document new license section in README

## Testing
- `pytest -q` *(fails: No module named 'PySide6', No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6847d76c191483269edc5d6d69ac49fe