### PR TITLE
Fix README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # codex_try
 
 
-[![Tests](https://github.com/OWNER/REPO/actions/workflows/test.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/test.yml)
+[![Tests](https://github.com/tulipoaaaaa/codex_try/actions/workflows/test.yml/badge.svg)](https://github.com/tulipoaaaaa/codex_try/actions/workflows/test.yml)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- link README test badge to real GitHub Actions workflow

## Testing
- `PYTEST_QT_STUBS=1 pytest -q` *(fails: cannot import `set_key` from `dotenv`)*

------
https://chatgpt.com/codex/tasks/task_e_6847db8688b083269d9d18ee0201c1c1