### PR TITLE
Add CLI vs GUI matrix

### DIFF
--- a/docs/cli_vs_gui_matrix.md
+++ b/docs/cli_vs_gui_matrix.md
@@ -1,0 +1,18 @@
+# CLI vs GUI Feature Matrix
+
+The table below outlines which parts of the project are available via command-line tools and which require the graphical interface.
+
+| Feature | Command Line (`cli/execute_from_config.py` and `CorpusBuilderApp/cli.py`) | GUI Application |
+|--------|:--:|:--:|
+| Run collectors to download data | ✅ | ✅ |
+| Run processing modules | ✅ | ✅ |
+| Corpus balancing | ✅ | ✅ |
+| Browse and edit corpus files | ❌ | ✅ |
+| Real-time progress UI | ❌ | ✅ |
+| Analytics dashboards | ❌ | ✅ |
+| Theme and notification settings | ❌ | ✅ |
+| Configuration management | ✅ (via YAML) | ✅ (via settings tabs) |
+| View logs | ✅ (console) | ✅ (dedicated tab) |
+| Start individual collectors with custom arguments | ✅ | ✅ (through UI forms) |
+
+Use the command-line tools for headless batch operations or automation scripts. Launch the GUI for an interactive experience with corpus management, analytics and visual feedback.


### PR DESCRIPTION
## Summary
- add `docs/` directory for additional documentation
- document feature coverage across command-line tools and GUI

## Testing
- `PYTEST_QT_STUBS=1 pytest -k "non_existent_test_pattern" -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6847db8b56d0832687d0b7340091502a