### PR TITLE
Add diff-corpus CLI command

### DIFF
--- a/CorpusBuilderApp/cli.py
+++ b/CorpusBuilderApp/cli.py
@@ -4,6 +4,7 @@ Crypto Corpus Builder - Project-wide CLI
 
 Usage:
   python cli.py --collector <name> --config <config.yaml> [--args ...]
+  python cli.py diff-corpus --profile-a <profile1.json> --profile-b <profile2.json>
 
 Supported collectors:
   fred        - FRED (Federal Reserve Economic Data)
@@ -16,13 +17,20 @@ Examples:
   python cli.py --collector fred --config shared_tools/test_config.yaml --series-ids GDP CPI
   python cli.py --collector github --config shared_tools/test_config.yaml --search-terms bitcoin trading
   python cli.py --collector annas --config shared_tools/test_config.yaml --query "Mastering Bitcoin"
+  python cli.py diff-corpus --profile-a profile1.json --profile-b profile2.json
 
 All API keys and credentials are loaded from .env or environment variables.
 """
 import argparse
 import os
 import sys
+from pathlib import Path
 from dotenv import load_dotenv
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+import json
+
+from tools.diff_corpus_profiles import diff_profiles, format_report
 
 # Load .env if present
 load_dotenv()
@@ -38,18 +46,59 @@ except ImportError as e:
     print(f"[ERROR] Could not import collectors: {e}")
     sys.exit(1)
 
-def main():
+
+def _load_profile(path: str) -> dict:
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Profile not found: {path}")
+    with open(path, "r", encoding="utf-8") as fh:
+        try:
+            return json.load(fh)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def cmd_diff_corpus(args: argparse.Namespace) -> int:
+    """Handle the diff-corpus subcommand."""
+    try:
+        a = _load_profile(args.profile_a)
+        b = _load_profile(args.profile_b)
+    except Exception as exc:  # pragma: no cover - simple CLI validation
+        print(f"[ERROR] {exc}")
+        return 2
+
+    diff = diff_profiles(a, b)
+    print(format_report(diff))
+
+    differences = (
+        diff["total_file_delta"]
+        or diff["total_token_delta"]
+        or diff["new_hashes"]
+        or diff["removed_hashes"]
+        or any(row.get("delta") for row in diff["domains"])
+    )
+    return 1 if differences else 0
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(argv) if argv is not None else sys.argv[1:]
+
+    if argv and argv[0] == "diff-corpus":
+        diff_parser = argparse.ArgumentParser(prog="diff-corpus", description="Compare two corpus profiles")
+        diff_parser.add_argument("--profile-a", required=True, help="Path to first corpus profile JSON")
+        diff_parser.add_argument("--profile-b", required=True, help="Path to second corpus profile JSON")
+        diff_args = diff_parser.parse_args(argv[1:])
+        return cmd_diff_corpus(diff_args)
+
     parser = argparse.ArgumentParser(description="Crypto Corpus Builder CLI")
-    parser.add_argument('--collector', required=True, choices=['fred', 'github', 'annas', 'scidb', 'web'], help='Collector to run')
-    parser.add_argument('--config', required=True, help='Path to config YAML')
-    parser.add_argument('--series-ids', nargs='*', help='FRED: List of series IDs')
-    parser.add_argument('--search-terms', nargs='*', help='GitHub: List of search terms')
-    parser.add_argument('--query', type=str, help="Annas: Search query")
-    parser.add_argument('--topic', type=str, help='GitHub: Topic to search for')
-    parser.add_argument('--max-repos', type=int, default=10, help='GitHub: Max repos')
-    parser.add_argument('--max-results', type=int, default=100, help='FRED: Max results')
-    parser.add_argument('--output-dir', type=str, help='Output directory (for annas, scidb, web)')
-    args = parser.parse_args()
+    parser.add_argument("--collector", required=True, choices=["fred", "github", "annas", "scidb", "web"], help="Collector to run")
+    parser.add_argument("--config", required=True, help="Path to config YAML")
+    parser.add_argument("--series-ids", nargs="*", help="FRED: List of series IDs")
+    parser.add_argument("--search-terms", nargs="*", help="GitHub: List of search terms")
+    parser.add_argument("--query", type=str, help="Annas: Search query")
+    parser.add_argument("--topic", type=str, help="GitHub: Topic to search for")
+    parser.add_argument("--max-repos", type=int, default=10, help="GitHub: Max repos")
+    parser.add_argument("--max-results", type=int, default=100, help="FRED: Max results")
+    parser.add_argument("--output-dir", type=str, help="Output directory (for annas, scidb, web)")
+    args = parser.parse_args(argv)
 
     if args.collector == 'fred':
         collector = FREDCollector(args.config)
@@ -96,5 +145,7 @@ def main():
         print(f"[ERROR] Unknown collector: {args.collector}")
         sys.exit(1)
 
+    return 0
+
 if __name__ == "__main__":
-    main() 
+    sys.exit(main())

--- a/tests/unit/test_diff_corpus_cli.py
+++ b/tests/unit/test_diff_corpus_cli.py
@@ -1,0 +1,52 @@
+import sys
+import types
+import json
+
+# Stub heavy modules before importing CLI
+for mod in [
+    "pandas",
+    "numpy",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "seaborn",
+    "plotly",
+    "plotly.subplots",
+    "plotly.graph_objects",
+    "plotly.express",
+    "requests",
+    "yaml",
+]:
+    sys.modules.setdefault(mod, types.ModuleType(mod))
+
+import CorpusBuilderApp.cli as cli  # noqa: E402
+
+
+def test_diff_corpus_no_changes(tmp_path, capsys):
+    data = {
+        "domains": {"a": {"txt": 1, "json": 1}},
+        "total_files": 2,
+        "total_tokens": 10,
+        "hashes": ["h1"],
+    }
+    p1 = tmp_path / "p1.json"
+    p2 = tmp_path / "p2.json"
+    p1.write_text(json.dumps(data))
+    p2.write_text(json.dumps(data))
+
+    exit_code = cli.main(["diff-corpus", "--profile-a", str(p1), "--profile-b", str(p2)])
+    captured = capsys.readouterr().out
+    assert "Total file delta: 0" in captured
+    assert exit_code == 0
+
+
+def test_diff_corpus_detect_changes(tmp_path, capsys):
+    p1 = tmp_path / "a.json"
+    p2 = tmp_path / "b.json"
+    p1.write_text(json.dumps({"domains": {}, "total_files": 0, "total_tokens": 0, "hashes": []}))
+    p2.write_text(
+        json.dumps({"domains": {"x": {"txt": 1, "json": 0}}, "total_files": 1, "total_tokens": 5, "hashes": ["a"]})
+    )
+    exit_code = cli.main(["diff-corpus", "--profile-a", str(p1), "--profile-b", str(p2)])
+    out = capsys.readouterr().out
+    assert "Total file delta: 1" in out
+    assert exit_code == 1


### PR DESCRIPTION
## Summary
- integrate diff_corpus_profiles as `diff-corpus` command
- load profile JSON files and report differences
- exit with non-zero status when diffs found
- add unit tests for the new command

## Testing
- `ruff check CorpusBuilderApp/cli.py tests/unit/test_diff_corpus_cli.py`
- `pytest tests/unit/test_diff_corpus_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6847e0a1be208326af42ed9283442723