### PR TITLE
Finalize CLI version flags and test markers

### DIFF
--- a/CorpusBuilderApp/__init__.py
+++ b/CorpusBuilderApp/__init__.py
@@ -1,0 +1,6 @@
+
+"""Package entry with version metadata."""
+
+__all__ = ["__version__"]
+
+__version__ = "1.0.0"

--- a/CorpusBuilderApp/cli.py
+++ b/CorpusBuilderApp/cli.py
@@ -29,6 +29,20 @@ import sys
 from pathlib import Path
 from dotenv import load_dotenv
 
+from CorpusBuilderApp import __version__
+
+PARITY_TABLE = """
+CLI Command          | GUI Equivalent
+---------------------+--------------------------
+--collector fred     | Collectors -> FRED
+--collector github   | Collectors -> GitHub
+--collector annas    | Collectors -> Annas
+--collector scidb    | Collectors -> SciDB
+--collector web      | Collectors -> General Web
+diff-corpus          | Tools -> Diff Corpus Profiles
+export-corpus        | Tools -> Export Corpus
+"""
+
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 import json
 
@@ -82,6 +96,14 @@ def cmd_diff_corpus(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     argv = list(argv) if argv is not None else sys.argv[1:]
+
+    if "--version" in argv:
+        print(__version__)
+        return 0
+
+    if "--matrix" in argv:
+        print(PARITY_TABLE)
+        return 0
 
     if argv and argv[0] == "diff-corpus":
         diff_parser = argparse.ArgumentParser(prog="diff-corpus", description="Compare two corpus profiles")

--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@
 
 ## Installation
 
-Install the runtime requirements and then the development extras:
+Install the full development requirements and then any development extras:
 
 ```bash
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
 ```
 
-These files are kept separate so the core application dependencies remain
-lightweight.
+`requirements.txt` contains all runtime and development dependencies. For
+minimal Docker or PyInstaller builds use `requirements.runtime.txt` instead,
+which only includes the packages needed at runtime. The optional
+`requirements-dev.txt` file adds linting and test tools.
 
 ## Testing
 

--- a/requirements.runtime.txt
+++ b/requirements.runtime.txt
@@ -1,0 +1,7 @@
+PySide6
+qdarktheme
+PyYAML
+python-dotenv
+requests
+PyPDF2
+pydantic

--- a/tests/cli/test_execute_from_config.py
+++ b/tests/cli/test_execute_from_config.py
@@ -3,6 +3,9 @@ from pathlib import Path as _Path, Path
 import types
 from typing import List
 import yaml
+import pytest
+
+pytestmark = pytest.mark.optional_dependency
 
 
 

--- a/tests/test_processors_tab_connections.py
+++ b/tests/test_processors_tab_connections.py
@@ -2,6 +2,8 @@ import sys
 import types
 import pytest
 
+pytestmark = pytest.mark.optional_dependency
+
 from PySide6.QtWidgets import QApplication
 
 # Stub heavy wrapper modules before importing the tab module

--- a/tests/ui/test_balancer_tab.py
+++ b/tests/ui/test_balancer_tab.py
@@ -2,6 +2,8 @@ import sys
 import types
 import pytest
 
+pytestmark = pytest.mark.optional_dependency
+
 # Ensure required Qt classes exist before importing the tab module
 from PySide6 import QtWidgets, QtGui, QtCore
 

--- a/tests/ui/test_configuration_tab.py
+++ b/tests/ui/test_configuration_tab.py
@@ -2,6 +2,8 @@ import os
 import types
 import pytest
 
+pytestmark = pytest.mark.optional_dependency
+
 try:
     from PySide6.QtCore import Qt
     from app.ui.tabs.configuration_tab import ConfigurationTab

--- a/tests/ui/test_corpus_manager_tab.py
+++ b/tests/ui/test_corpus_manager_tab.py
@@ -3,6 +3,8 @@ import pytest
 from PySide6.QtCore import QObject, Signal as pyqtSignal
 from PySide6.QtWidgets import QPushButton
 
+pytestmark = pytest.mark.optional_dependency
+
 from app.ui.tabs import corpus_manager_tab as cmt
 
 

--- a/tests/ui_wrappers/test_balancer_wrapper.py
+++ b/tests/ui_wrappers/test_balancer_wrapper.py
@@ -2,6 +2,8 @@ import sys
 import types
 import pytest
 
+pytestmark = pytest.mark.optional_dependency
+
 class _Signal:
     def __init__(self, *a, **k):
         self._slots = []

--- a/tests/unit/test_corpus_balancer_wrapper.py
+++ b/tests/unit/test_corpus_balancer_wrapper.py
@@ -2,6 +2,8 @@ import sys
 import types
 import pytest
 
+pytestmark = pytest.mark.optional_dependency
+
 # Provide minimal stubs for heavy dependencies before importing the wrapper
 class _Signal:
     def __init__(self, *a, **k):

--- a/tests/unit/test_system_monitor.py
+++ b/tests/unit/test_system_monitor.py
@@ -4,6 +4,8 @@ import types
 
 import pytest
 
+pytestmark = pytest.mark.optional_dependency
+
 
 class DummyTimer:
     def __init__(self, *args, **kwargs):

--- a/tests/unit/test_tab_audit_service.py
+++ b/tests/unit/test_tab_audit_service.py
@@ -1,7 +1,10 @@
 import os
+import pytest
 
 # Ensure Qt is stubbed
 os.environ.setdefault("PYTEST_QT_STUBS", "1")
+
+pytestmark = pytest.mark.optional_dependency
 
 from shared_tools.services.tab_audit_service import TabAuditService
 

--- a/tests/unit/test_task_queue_manager.py
+++ b/tests/unit/test_task_queue_manager.py
@@ -1,5 +1,8 @@
 import sys
 import types
+import pytest
+
+pytestmark = pytest.mark.optional_dependency
 
 class DummySignal:
     def __init__(self, *a, **k):

--- a/tests/wrappers/test_worker_threads.py
+++ b/tests/wrappers/test_worker_threads.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from types import SimpleNamespace
 import pytest
 
+pytestmark = pytest.mark.optional_dependency
+
 
 
 # Stub heavy third-party dependencies


### PR DESCRIPTION
## Summary
- set `__version__` in package init
- implement `--version` and `--matrix` CLI options
- add compact runtime requirements file
- document runtime vs development requirements
- mark UI and YAML dependent tests as `optional_dependency`
- register pytest marker and stub optional modules

## Testing
- `PYTEST_QT_STUBS=1 pytest --collect-only`
- `PYTEST_QT_STUBS=1 pytest -q` *(fails: AttributeError: <module 'requests'> does not have the attribute 'get')*

------
https://chatgpt.com/codex/tasks/task_e_6847ec2e48148326825ceadf2b972841