### PR TITLE
Add TaskQueueManager integration in wrappers

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/collectors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/collectors_tab.py
@@ -38,10 +38,17 @@ class CollectorsTab(QWidget):
     collection_finished = pyqtSignal(str, bool)
     collector_error = pyqtSignal(str, str)
 
-    def __init__(self, project_config, task_history_service=None, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        project_config,
+        task_history_service=None,
+        task_queue_manager=None,
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent)
         self.project_config = project_config
         self.task_history_service = task_history_service
+        self.task_queue_manager = task_queue_manager
         self._task_ids: dict[str, str] = {}
         self.cards: dict[str, CollectorCard] = {}
         
@@ -57,6 +64,10 @@ class CollectorsTab(QWidget):
             'scidb': SciDBWrapper(self.project_config),
             'web': WebWrapper(self.project_config)
         }
+
+        if self.task_queue_manager:
+            for wrapper in self.collector_wrappers.values():
+                wrapper.task_queue_manager = self.task_queue_manager
         
         # Configure wrappers from project config
         for name, wrapper in self.collector_wrappers.items():

--- a/CorpusBuilderApp/app/ui/tabs/processors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/processors_tab.py
@@ -30,10 +30,17 @@ from app.helpers.notifier import Notifier
 
 
 class ProcessorsTab(QWidget):
-    def __init__(self, project_config, task_history_service=None, parent=None):
+    def __init__(
+        self,
+        project_config,
+        task_history_service=None,
+        task_queue_manager=None,
+        parent=None,
+    ):
         super().__init__(parent)
         self.project_config = project_config
         self.task_history_service = task_history_service
+        self.task_queue_manager = task_queue_manager
         self._task_ids = {}
         self.processor_wrappers = {}
         self.file_queue = []
@@ -471,7 +478,12 @@ class ProcessorsTab(QWidget):
                 except Exception as e:
                     print(f"ERROR: Failed to initialize {wrapper_class.__name__}: {e}")
                     self.processor_wrappers[name] = None
-            
+
+            if self.task_queue_manager:
+                for wrapper in self.processor_wrappers.values():
+                    if wrapper:
+                        wrapper.task_queue_manager = self.task_queue_manager
+
             print("DEBUG: Processor wrapper initialization completed")
             
         except Exception as e:

--- a/tests/unit/test_base_wrapper_task_queue.py
+++ b/tests/unit/test_base_wrapper_task_queue.py
@@ -1,0 +1,61 @@
+import sys
+import types
+import pytest
+
+pytestmark = pytest.mark.optional_dependency
+
+class DummySignal:
+    def __init__(self):
+        self._slots = []
+    def connect(self, slot):
+        self._slots.append(slot)
+    def emit(self, *args):
+        for s in self._slots:
+            s(*args)
+
+qtcore = types.SimpleNamespace(
+    QObject=type("QObject", (), {"__init__": lambda self, *a, **k: None}),
+    Signal=lambda *a, **k: DummySignal(),
+    QThread=object,
+    QTimer=object,
+    qInstallMessageHandler=lambda *a, **k: None,
+)
+sys.modules["PySide6"] = types.SimpleNamespace(QtCore=qtcore)
+sys.modules["PySide6.QtCore"] = qtcore
+
+from shared_tools.services.task_queue_manager import TaskQueueManager
+from shared_tools.ui_wrappers import base_wrapper as bw
+
+class DummyThread:
+    def __init__(self, *a, **k):
+        self.progress = bw.DummySignal()
+        self.error = bw.DummySignal()
+        self.finished = bw.DummySignal()
+    def start(self):
+        self.progress.emit(1, 1, "done")
+        self.finished.emit({})
+    def isRunning(self):
+        return False
+    def stop(self):
+        pass
+    def wait(self):
+        pass
+
+class SimpleWrapper(bw.BaseWrapper):
+    def _create_target_object(self):
+        return object()
+    def _get_operation_type(self):
+        return "collect"
+
+
+def test_queue_counts_update_on_start(monkeypatch):
+    monkeypatch.setattr(bw, "BaseWorkerThread", DummyThread)
+    manager = TaskQueueManager(test_mode=True)
+    wrapper = SimpleWrapper({}, task_queue_manager=manager, test_mode=True)
+    counts = []
+    manager.queue_counts_changed.connect(lambda p, r, f, c: counts.append((p, r, f, c)))
+
+    wrapper.start()
+
+    assert counts[0] == (1, 0, 0, 0)
+    assert counts[-1] == (0, 0, 0, 1)


### PR DESCRIPTION
## Summary
- extend BaseWrapper to register TaskQueueManager
- push queue updates on progress, finish, error and stop
- wire queue manager through collectors and processors tabs
- test queue handling with a dummy wrapper

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/unit/test_task_queue_manager.py tests/unit/test_base_wrapper_task_queue.py`

------
https://chatgpt.com/codex/tasks/task_e_68480e6689988326b78fae71f4003e68