### PR TITLE
UI visual consistency update

### DIFF
--- a/CorpusBuilderApp/app/resources/styles/theme_dark.qss
+++ b/CorpusBuilderApp/app/resources/styles/theme_dark.qss
@@ -732,3 +732,14 @@ QLabel[objectName^="status-dot-"] {
 QLabel[objectName="status-dot-active"] { background: #10b981; }
 QLabel[objectName="status-dot-processing"] { background: #06b6d4; }
 QLabel[objectName="status-dot-idle"] { background: #6b7280; }
+
+QTableView::item:alternate, QTableWidget::item:alternate {
+    background-color: #1d232a;
+}
+QPushButton[objectName="danger"] {
+    background-color: #FF5459;
+    color: #FFFFFF;
+}
+QPushButton[objectName="danger"]:hover {
+    background-color: #e74c3c;
+}

--- a/CorpusBuilderApp/app/resources/styles/theme_light.qss
+++ b/CorpusBuilderApp/app/resources/styles/theme_light.qss
@@ -347,3 +347,14 @@ QFrame[objectName="card"] QChartView {
     color: transparent; /* Hide the title since we have separate header */
 }
 
+QTableView::item:alternate, QTableWidget::item:alternate {
+    background-color: #F5F5F5;
+}
+QPushButton[objectName="danger"] {
+    background-color: #FF5459;
+    color: #FFFFFF;
+}
+QPushButton[objectName="danger"]:hover {
+    background-color: #E32F37;
+}
+

--- a/CorpusBuilderApp/app/ui/tabs/analytics_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/analytics_tab.py
@@ -18,6 +18,7 @@ from app.helpers.chart_manager import ChartManager
 from app.ui.widgets.card_wrapper import CardWrapper
 from app.ui.widgets.section_header import SectionHeader
 from shared_tools.services.corpus_stats_service import CorpusStatsService
+from app.ui.theme.theme_constants import PAGE_MARGIN
 
 import datetime
 
@@ -48,8 +49,8 @@ class AnalyticsTab(QWidget):
         scroll.setWidget(container)
 
         main_layout = QVBoxLayout(container)
-        main_layout.setSpacing(32)
-        main_layout.setContentsMargins(32, 32, 32, 32)
+        main_layout.setSpacing(PAGE_MARGIN)
+        main_layout.setContentsMargins(PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN)
         
         # Page header
         header = SectionHeader("Analytics")

--- a/CorpusBuilderApp/app/ui/tabs/collectors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/collectors_tab.py
@@ -28,6 +28,7 @@ from app.ui.theme.theme_constants import (
     DEFAULT_FONT_SIZE,
     CARD_MARGIN,
     BUTTON_COLOR_DANGER,
+    PAGE_MARGIN,
 )
 
 
@@ -77,6 +78,8 @@ class CollectorsTab(QWidget):
     def setup_ui(self) -> None:
         """Initialize the user interface."""
         layout = QVBoxLayout(self)
+        layout.setContentsMargins(PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN)
+        layout.setSpacing(PAGE_MARGIN)
         
         # Status section
         status_group = QGroupBox("Collection Status")
@@ -127,9 +130,9 @@ class CollectorsTab(QWidget):
         
         # Control buttons
         control_layout = QHBoxLayout()
-        
+
         stop_all_btn = QPushButton("Stop All Collectors")
-        stop_all_btn.setStyleSheet(f"background-color: {BUTTON_COLOR_DANGER};")
+        stop_all_btn.setObjectName("danger")
         stop_all_btn.clicked.connect(self.stop_all_collectors)
         control_layout.addWidget(stop_all_btn)
         

--- a/CorpusBuilderApp/app/ui/tabs/configuration_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/configuration_tab.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from dotenv import load_dotenv, set_key
 from pydantic import ValidationError
 from app.helpers.crypto_utils import encrypt_value, decrypt_value
+from app.ui.widgets.section_header import SectionHeader
+from app.ui.theme.theme_constants import PAGE_MARGIN
 
 
 class ConfigurationTab(QWidget):
@@ -28,6 +30,8 @@ class ConfigurationTab(QWidget):
         
     def setup_ui(self):
         main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN)
+        main_layout.setSpacing(PAGE_MARGIN)
         
         # Create tabs for different configuration sections
         self.config_tabs = QTabWidget()
@@ -313,6 +317,7 @@ class ConfigurationTab(QWidget):
         self.domains_table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
         self.domains_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
         self.domains_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        self.domains_table.setAlternatingRowColors(True)
         
         # Initialize with domains
         domains = [
@@ -346,7 +351,7 @@ class ConfigurationTab(QWidget):
             self.domains_table.setItem(i, 1, QTableWidgetItem(str(target)))
             self.domains_table.setItem(i, 2, QTableWidgetItem(desc))
         
-        layout.addWidget(QLabel("Domain Configuration:"))
+        layout.addWidget(SectionHeader("Domain Configuration"))
         layout.addWidget(self.domains_table)
         
         # Domain options

--- a/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
@@ -37,6 +37,7 @@ from app.helpers.notifier import Notifier
 from app.ui.widgets.card_wrapper import CardWrapper
 from app.ui.widgets.section_header import SectionHeader
 from app.ui.widgets.status_dot import StatusDot
+from app.ui.theme.theme_constants import PAGE_MARGIN
 from shared_tools.storage.corpus_manager import CorpusManager
 
 class NotificationManager(QWidget):
@@ -153,8 +154,8 @@ class CorpusManagerTab(QWidget):
         scroll_area.setWidget(container)
 
         main_layout = QVBoxLayout(container)
-        main_layout.setContentsMargins(16, 16, 16, 16)
-        main_layout.setSpacing(16)
+        main_layout.setContentsMargins(PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN)
+        main_layout.setSpacing(PAGE_MARGIN)
 
         icon_manager = IconManager()
 
@@ -281,10 +282,11 @@ class CorpusManagerTab(QWidget):
         self.metadata_model = QStandardItemModel(0, 2)
         self.metadata_model.setHorizontalHeaderLabels(["Property", "Value"])
         self.metadata_table.setModel(self.metadata_model)
-        
+
         # Make the table more user-friendly
         self.metadata_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
         self.metadata_table.verticalHeader().setVisible(False)
+        self.metadata_table.setAlternatingRowColors(True)
         
         metadata_inner_layout.addWidget(self.metadata_table)
         
@@ -337,6 +339,7 @@ class CorpusManagerTab(QWidget):
         actions_layout.addWidget(move_card)
 
         self.batch_delete_btn = QPushButton("Delete")
+        self.batch_delete_btn.setObjectName("danger")
         delete_card = self.create_action_card("Delete Files", self.batch_delete_files, self.batch_delete_btn)
         actions_layout.addWidget(delete_card)
 

--- a/CorpusBuilderApp/app/ui/tabs/logs_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/logs_tab.py
@@ -21,6 +21,7 @@ from app.ui.widgets.section_header import SectionHeader
 from app.ui.widgets.status_dot import StatusDot
 from shared_tools.services.activity_log_service import ActivityLogService
 from shared_tools.utils.log_file_parser import LogFileParser
+from app.ui.theme.theme_constants import PAGE_MARGIN
 
 import os
 import re
@@ -41,6 +42,8 @@ class LogsTab(QWidget):
         
     def setup_ui(self):
         main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN)
+        main_layout.setSpacing(PAGE_MARGIN)
 
         header = SectionHeader("Logs")
         main_layout.addWidget(header)
@@ -95,6 +98,7 @@ class LogsTab(QWidget):
         self.log_table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
         self.log_table.horizontalHeader().setSectionResizeMode(3, QHeaderView.ResizeMode.Stretch)
         self.log_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.log_table.setAlternatingRowColors(True)
         self.log_table.clicked.connect(self.on_log_entry_selected)
         
         table_card = CardWrapper(title="Entries")

--- a/CorpusBuilderApp/app/ui/tabs/monitoring_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/monitoring_tab.py
@@ -1,4 +1,5 @@
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QProgressBar
+from app.ui.theme.theme_constants import PAGE_MARGIN
 from PySide6.QtCore import Slot
 from shared_tools.ui_wrappers.processors.monitor_progress_wrapper import MonitorProgressWrapper
 from shared_tools.services.system_monitor import SystemMonitor
@@ -7,6 +8,8 @@ class MonitoringTab(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         layout = QVBoxLayout(self)
+        layout.setContentsMargins(PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN)
+        layout.setSpacing(PAGE_MARGIN)
 
         # Progress widget provided by the shared wrapper
         self.monitor_widget = MonitorProgressWrapper()

--- a/CorpusBuilderApp/app/ui/tabs/processors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/processors_tab.py
@@ -27,6 +27,7 @@ from shared_tools.ui_wrappers.processors.corpus_balancer_wrapper import CorpusBa
 from .corpus_manager_tab import NotificationManager
 from app.helpers.icon_manager import IconManager
 from app.helpers.notifier import Notifier
+from app.ui.theme.theme_constants import PAGE_MARGIN
 
 
 class ProcessorsTab(QWidget):
@@ -45,6 +46,8 @@ class ProcessorsTab(QWidget):
 
     def setup_ui(self):
         main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN)
+        main_layout.setSpacing(PAGE_MARGIN)
         icon_manager = IconManager()
         
         # Create tabs for different processor types with icons
@@ -75,6 +78,7 @@ class ProcessorsTab(QWidget):
         
         # Button for stopping all processors
         stop_all_btn = QPushButton("Stop All Processors")
+        stop_all_btn.setObjectName("danger")
         stop_all_btn.clicked.connect(self.stop_all_processors)
         status_layout.addWidget(stop_all_btn)
         
@@ -146,6 +150,7 @@ class ProcessorsTab(QWidget):
         if start_icon:
             self.pdf_start_btn.setIcon(QIcon(start_icon))
         self.pdf_stop_btn = QPushButton("Stop")
+        self.pdf_stop_btn.setObjectName("danger")
         stop_icon = icon_manager.get_icon_path('Stop operation control', by='Function')
         if stop_icon:
             self.pdf_stop_btn.setIcon(QIcon(stop_icon))
@@ -237,6 +242,7 @@ class ProcessorsTab(QWidget):
         if start_icon:
             self.text_start_btn.setIcon(QIcon(start_icon))
         self.text_stop_btn = QPushButton("Stop")
+        self.text_stop_btn.setObjectName("danger")
         stop_icon = icon_manager.get_icon_path('Stop operation control', by='Function')
         if stop_icon:
             self.text_stop_btn.setIcon(QIcon(stop_icon))
@@ -391,6 +397,7 @@ class ProcessorsTab(QWidget):
         if start_icon:
             self.batch_start_btn.setIcon(QIcon(start_icon))
         self.batch_stop_btn = QPushButton("Stop")
+        self.batch_stop_btn.setObjectName("danger")
         stop_icon = icon_manager.get_icon_path('Stop operation control', by='Function')
         if stop_icon:
             self.batch_stop_btn.setIcon(QIcon(stop_icon))

--- a/CorpusBuilderApp/app/ui/theme/theme_constants.py
+++ b/CorpusBuilderApp/app/ui/theme/theme_constants.py
@@ -4,6 +4,9 @@ DEFAULT_FONT_SIZE = 14
 CARD_MARGIN = 16
 CARD_PADDING = 24
 
+# Consistent margin for pages and major layouts
+PAGE_MARGIN = 32
+
 # Button colors for consistent styling
 BUTTON_COLOR_PRIMARY = "#32B8C6"
 BUTTON_COLOR_DANGER = "#FF5459"


### PR DESCRIPTION
## Summary
- add `PAGE_MARGIN` constant for standard layout spacing
- style dark and light themes for alternating table rows and danger buttons
- adjust layout margins/spacings across UI tabs to use `PAGE_MARGIN`
- mark destructive buttons with `objectName="danger"`
- enable alternating row colors on tables

## Testing
- `pytest -q` *(fails: qInstallMessageHandler() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_684812596d208326b6f48eea22edf0be