### PR TITLE
Update dashboard task queue

### DIFF
--- a/CorpusBuilderApp/app/main_window.py
+++ b/CorpusBuilderApp/app/main_window.py
@@ -47,6 +47,7 @@ from shared_tools.ui_wrappers.processors.corpus_balancer_wrapper import CorpusBa
 from shared_tools.services.activity_log_service import ActivityLogService
 from shared_tools.services.task_history_service import TaskHistoryService
 from shared_tools.services.tab_audit_service import TabAuditService
+from shared_tools.services.task_queue_manager import TaskQueueManager
 
 class CryptoCorpusMainWindow(QMainWindow):
     """Main application window"""
@@ -66,6 +67,7 @@ class CryptoCorpusMainWindow(QMainWindow):
         # Services and wrappers
         self.activity_log_service = ActivityLogService()
         self.task_history_service = TaskHistoryService()
+        self.task_queue_manager = TaskQueueManager()
         self.balancer_wrapper = CorpusBalancerWrapper(self.config)
         self.balancer_wrapper.balance_completed.connect(self.on_balance_completed)
         
@@ -139,7 +141,11 @@ class CryptoCorpusMainWindow(QMainWindow):
             )
             # Dashboard tab
             self.logger.debug("Initializing DashboardTab...")
-            self.dashboard_tab = DashboardTab(self.config, self.activity_log_service)
+            self.dashboard_tab = DashboardTab(
+                self.config,
+                self.activity_log_service,
+                task_queue_manager=self.task_queue_manager,
+            )
             self.logger.debug("DashboardTab initialized successfully")
             self.tab_widget.addTab(self.dashboard_tab, "📊 Dashboard")
             # Collectors tab

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/monitor_progress_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/monitor_progress_wrapper.py
@@ -7,14 +7,51 @@ import os
 import time
 import json
 from typing import Dict, List, Optional, Any, Callable
-from PySide6.QtCore import QObject, QThread, Signal as pyqtSignal, Slot as pyqtSlot, QTimer, QMutex
-from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QPushButton, 
-                           QProgressBar, QLabel, QTextEdit, QCheckBox, 
-                           QSpinBox, QGroupBox, QGridLayout, QComboBox,
-                           QTableWidget, QTableWidgetItem, QHeaderView,
-                           QTabWidget, QSplitter, QSlider, QListWidget)
-from PySide6.QtGui import QColor, QBrush, QPalette
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QObject, QThread, Signal as pyqtSignal, QTimer
+try:
+    from PySide6.QtCore import QMutex
+except Exception:  # pragma: no cover - fallback for stub environments
+    class QMutex:  # type: ignore
+        def lock(self):
+            pass
+        def unlock(self):
+            pass
+try:  # Handle stubs missing Slot
+    from PySide6.QtCore import Slot as pyqtSlot
+except Exception:  # pragma: no cover - fallback for stub environments
+    def pyqtSlot(*args, **kwargs):  # type: ignore
+        def decorator(func):
+            return func
+        return decorator
+try:
+    from PySide6.QtWidgets import (
+        QWidget,
+        QVBoxLayout,
+        QHBoxLayout,
+        QPushButton,
+        QProgressBar,
+        QLabel,
+        QTextEdit,
+        QCheckBox,
+        QSpinBox,
+        QGroupBox,
+        QGridLayout,
+        QComboBox,
+        QTableWidget,
+        QTableWidgetItem,
+        QHeaderView,
+        QTabWidget,
+        QSplitter,
+        QSlider,
+        QListWidget,
+    )
+    from PySide6.QtGui import QColor, QBrush, QPalette
+    from PySide6.QtCore import Qt
+except Exception:  # pragma: no cover - fallback for stubs
+    QWidget = QVBoxLayout = QHBoxLayout = QPushButton = QProgressBar = QLabel = QTextEdit = QCheckBox = QSpinBox = QGroupBox = QGridLayout = QComboBox = QTableWidget = QTableWidgetItem = QHeaderView = QTabWidget = QSplitter = QSlider = QListWidget = object
+    QColor = QBrush = QPalette = object
+    class Qt:
+        Orientation = type("Orientation", (), {"Horizontal": 0})
 from shared_tools.ui_wrappers.base_wrapper import BaseWrapper
 from shared_tools.processors.monitor_progress import MonitorProgress
 from shared_tools.processors.mixins.processor_wrapper_mixin import ProcessorWrapperMixin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,12 +77,17 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
     qtcore.QObject = type("QObject", (), {})
     qtcore.QThread = type("QThread", (), {})
     qtcore.QTimer = type("QTimer", (), {})
+    qtcore.QMutex = type("QMutex", (), {"lock": lambda *a, **k: None, "unlock": lambda *a, **k: None})
+    qtcore.qInstallMessageHandler = lambda *a, **k: None
+    qtcore.Slot = lambda *a, **k: (lambda f: f)
     sys.modules["PySide6.QtCore"] = qtcore
 
     sys.modules["PySide6.QtGui"] = _SafeStubModule("PySide6.QtGui")
     sys.modules["PySide6.QtCharts"] = _SafeStubModule("PySide6.QtCharts")
     sys.modules["PySide6.QtTest"] = _SafeStubModule("PySide6.QtTest")
-    sys.modules["PySide6.QtMultimedia"] = _SafeStubModule("PySide6.QtMultimedia")
+    qt_multimedia = _SafeStubModule("PySide6.QtMultimedia")
+    qt_multimedia.QSoundEffect = type("QSoundEffect", (), {})
+    sys.modules["PySide6.QtMultimedia"] = qt_multimedia
     pyside6 = types.ModuleType("PySide6")
     pyside6.QtWidgets = sys.modules["PySide6.QtWidgets"]
     pyside6.QtGui = sys.modules["PySide6.QtGui"]
@@ -103,6 +108,7 @@ for mod in [
     "yaml",
     "requests",
     "pandas",
+    "PyPDF2",
     "plotly",
     "plotly.graph_objects",
     "plotly.express",
@@ -124,6 +130,18 @@ for mod in [
     "psutil",
 ]:
     sys.modules.setdefault(mod, types.ModuleType(mod))
+
+requests_mod = sys.modules.setdefault('requests', types.ModuleType('requests'))
+setattr(requests_mod, 'get', lambda *a, **k: None)
+setattr(requests_mod, 'post', lambda *a, **k: None)
+exceptions_ns = types.SimpleNamespace(RequestException=Exception)
+setattr(exceptions_ns, 'Timeout', Exception)
+setattr(exceptions_ns, 'HTTPError', Exception)
+setattr(requests_mod, 'exceptions', exceptions_ns)
+
+yaml_mod = sys.modules.setdefault('yaml', types.ModuleType('yaml'))
+setattr(yaml_mod, 'safe_dump', lambda *a, **k: '')
+setattr(yaml_mod, 'safe_load', lambda *a, **k: {})
 
 bs4_mod = sys.modules.setdefault('bs4', types.ModuleType('bs4'))
 setattr(bs4_mod, 'BeautifulSoup', lambda *a, **k: None)
@@ -147,6 +165,8 @@ setattr(np_mod, 'array', lambda *a, **k: None)
 pd_mod = sys.modules.setdefault('pandas', types.ModuleType('pandas'))
 setattr(pd_mod, 'DataFrame', object)
 setattr(pd_mod, 'read_csv', lambda *a, **k: None)
+pypdf_mod = sys.modules.setdefault('PyPDF2', types.ModuleType('PyPDF2'))
+setattr(pypdf_mod, 'PdfReader', object)
 for plot_mod in ['plotly', 'plotly.graph_objects', 'plotly.express', 'plotly.subplots']:
     mod = sys.modules.setdefault(plot_mod, types.ModuleType(plot_mod))
     if plot_mod == 'plotly.subplots':
@@ -166,11 +186,19 @@ keyring_mod = sys.modules.setdefault('keyring', types.ModuleType('keyring'))
 setattr(keyring_mod, 'get_password', lambda *a, **k: None)
 setattr(keyring_mod, 'set_password', lambda *a, **k: None)
 pydantic_mod = sys.modules.setdefault('pydantic', types.ModuleType('pydantic'))
-setattr(pydantic_mod, 'BaseModel', object)
+class DummyBaseModel:
+    @classmethod
+    def parse_obj(cls, obj):
+        return cls()
+
+setattr(pydantic_mod, 'BaseModel', DummyBaseModel)
 setattr(pydantic_mod, 'validator', lambda *a, **k: (lambda f: f))
 setattr(pydantic_mod, 'field_validator', lambda *a, **k: (lambda f: f))
 setattr(pydantic_mod, 'Field', lambda *a, **k: None)
 setattr(pydantic_mod, 'ValidationError', type('ValidationError', (Exception,), {}))
+
+psutil_mod = sys.modules.setdefault('psutil', types.ModuleType('psutil'))
+setattr(psutil_mod, 'Process', lambda *a, **k: None)
 
 if "langdetect" not in sys.modules:
     langdetect = types.ModuleType("langdetect")


### PR DESCRIPTION
## Summary
- inject `TaskQueueManager` into `CryptoCorpusMainWindow`
- wire DashboardTab with queue manager for live progress
- make progress wrapper resilient to missing Qt classes
- extend test stubs for optional deps

## Testing
- `pytest -k 'not integration' -q` *(fails: module `shared_tools.ui_wrappers.processors.domain_classifier_wrapper` does not have attribute `DomainClassifier`)*

------
https://chatgpt.com/codex/tasks/task_e_684813fb5ea083269a51ffc2dd4ab039