### PR TITLE
Add SectionHeaders across UI tabs

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/collectors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/collectors_tab.py
@@ -23,6 +23,7 @@ from shared_tools.ui_wrappers.collectors.scidb_wrapper import SciDBWrapper
 from shared_tools.ui_wrappers.collectors.web_wrapper import WebWrapper
 
 from app.ui.widgets.collector_card import CollectorCard
+from app.ui.widgets.section_header import SectionHeader
 from app.helpers.notifier import Notifier
 from app.ui.theme.theme_constants import (
     DEFAULT_FONT_SIZE,
@@ -91,7 +92,10 @@ class CollectorsTab(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN)
         layout.setSpacing(PAGE_MARGIN)
-        
+
+        header = SectionHeader("Collectors")
+        layout.addWidget(header)
+
         # Status section
         status_group = QGroupBox("Collection Status")
         status_layout = QVBoxLayout(status_group)

--- a/CorpusBuilderApp/app/ui/tabs/monitoring_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/monitoring_tab.py
@@ -1,5 +1,6 @@
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QProgressBar
 from app.ui.theme.theme_constants import PAGE_MARGIN
+from app.ui.widgets.section_header import SectionHeader
 from PySide6.QtCore import Slot
 from shared_tools.ui_wrappers.processors.monitor_progress_wrapper import MonitorProgressWrapper
 from shared_tools.services.system_monitor import SystemMonitor
@@ -10,6 +11,9 @@ class MonitoringTab(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN)
         layout.setSpacing(PAGE_MARGIN)
+
+        header = SectionHeader("System Monitor")
+        layout.addWidget(header)
 
         # Progress widget provided by the shared wrapper
         self.monitor_widget = MonitorProgressWrapper()

--- a/CorpusBuilderApp/app/ui/tabs/processors_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/processors_tab.py
@@ -41,6 +41,7 @@ from shared_tools.ui_wrappers.processors.corpus_balancer_wrapper import CorpusBa
 from .corpus_manager_tab import NotificationManager
 from app.helpers.icon_manager import IconManager
 from app.helpers.notifier import Notifier
+from app.ui.widgets.section_header import SectionHeader
 from app.ui.theme.theme_constants import PAGE_MARGIN
 
 logger = logging.getLogger(__name__)
@@ -72,7 +73,10 @@ class ProcessorsTab(QWidget):
         main_layout.setContentsMargins(PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN, PAGE_MARGIN)
         main_layout.setSpacing(PAGE_MARGIN)
         icon_manager = IconManager()
-        
+
+        header = SectionHeader("Processors")
+        main_layout.addWidget(header)
+
         # Create tabs for different processor types with icons
         pdf_icon = icon_manager.get_icon_path('PDF document', by='Description') or icon_manager.get_icon_path('Main dashboard and analytics view', by='Function')
         text_icon = icon_manager.get_icon_path('Text Files', by='Description') or icon_manager.get_icon_path('File management and organization', by='Function')


### PR DESCRIPTION
## Summary
- include SectionHeader in CollectorsTab
- show Processors header on processors tab
- display System Monitor header in MonitoringTab

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684834c704288326bd4d90d709ebc184