### PR TITLE
Add environment configuration guide

### DIFF
--- a/CorpusBuilderApp/INSTALLATION.md
+++ b/CorpusBuilderApp/INSTALLATION.md
@@ -64,6 +64,10 @@ AA_ACCOUNT_COOKIE=your_cookie_here
 FRED_API_KEY=your_fred_key_here
 ```
 
+For a complete description of available environment variables and instructions
+on toggling between test and production modes, see
+[../docs/environment_config.md](../docs/environment_config.md).
+
 ### 6. Launch Application
 
 ```bash

--- a/CorpusBuilderApp/docs/readme.md
+++ b/CorpusBuilderApp/docs/readme.md
@@ -46,6 +46,9 @@ AA_ACCOUNT_COOKIE=your_anna_cookie
 FRED_API_KEY=your_fred_key
 ```
 
+See [../docs/environment_config.md](../docs/environment_config.md) for the full
+set of variables and instructions on selecting the active environment.
+
 ### Launch
 
 ```bash

--- a/CorpusBuilderApp/setup-and-docs.md
+++ b/CorpusBuilderApp/setup-and-docs.md
@@ -248,6 +248,10 @@ FRED_API_KEY=your_fred_key_here
 # Other API keys as needed
 ```
 
+For more environment variable examples and details on switching between test
+and production, see
+[../docs/environment_config.md](../docs/environment_config.md).
+
 ### 5. Directory Structure
 
 The application will automatically create the required directory structure on first run:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ minimal Docker or PyInstaller builds use `requirements.runtime.txt` instead,
 which only includes the packages needed at runtime. The optional
 `requirements-dev.txt` file adds linting and test tools.
 
+## Environment configuration
+
+See [docs/environment_config.md](docs/environment_config.md) for the list of
+required environment variables and details on switching between test and
+production modes.
+
 ## Testing
 
 The test suite can run without PySide6 installed by setting the environment

--- a/docs/environment_config.md
+++ b/docs/environment_config.md
@@ -1,0 +1,48 @@
+# Environment Configuration
+
+This project relies on several environment variables to locate configuration files and provide credentials for the collectors. Variables can be placed in a `.env` file at the repository root or exported in your shell. The `.env` file is automatically loaded when the application or tests start.
+
+## Example `.env` layout
+
+```bash
+# Select which configuration to load
+ENVIRONMENT=test  # or "production"
+
+# Optional paths
+PYTHON_PATH=/usr/bin/python3
+VENV_PATH=/home/user/venv
+TEMP_DIR=/tmp/ccb
+
+# API keys
+GITHUB_TOKEN=ghp_exampletoken
+AA_ACCOUNT_COOKIE=sessionid=abc123
+AA_COOKIE=sessionid=abc123   # alternate variable name
+FRED_API_KEY=fred_example
+BITMEX_API_KEY=bitmex_key
+BITMEX_API_SECRET=bitmex_secret
+ARXIV_EMAIL=user@example.com
+
+# Processing options
+PDF_THREADS=4
+TEXT_THREADS=4
+BATCH_SIZE=50
+MAX_RETRIES=3
+TIMEOUT=300
+
+# Corpus directories
+CORPUS_ROOT=/data/corpus
+RAW_DATA_DIR=/data/corpus/raw
+PROCESSED_DIR=/data/corpus/processed
+METADATA_DIR=/data/corpus/metadata
+LOGS_DIR=/data/corpus/logs
+```
+
+Only the variables relevant to your workflow need to be defined. If a value is omitted, sensible defaults from `ProjectConfig` will be used.
+
+## Switching between test and production
+
+The active environment is controlled by the `ENVIRONMENT` variable. Set it to `test` or `production` in your `.env` file (or export it in the shell) before launching the application or running command-line tools. The GUI also exposes an environment selector in the **Configuration** tab that updates the same value.
+
+Different YAML configuration files can be used for each environment (for example `config/test.yaml` and `config/production.yaml`). Changing `ENVIRONMENT` ensures the appropriate configuration is loaded.
+
+For automated tests or headless operation you can simply set `ENVIRONMENT=test`.


### PR DESCRIPTION
## Summary
- document all environment variables in `docs/environment_config.md`
- link the new doc from README and installation docs

## Testing
- `pytest -q` *(fails: AttributeError in collectors)*

------
https://chatgpt.com/codex/tasks/task_e_68483c1ef8248326a99919ac732fda17