### PR TITLE
Archive obsolete script

### DIFF
--- a/archive/extract_title_cache.py
+++ b/archive/extract_title_cache.py
@@ -1,3 +1,4 @@
+# DEPRECATED: Superseded by generate_title_cache.py
 import pandas as pd
 import re
 import datetime


### PR DESCRIPTION
## Summary
- add deprecation note for `extract_title_cache.py`
- archive `extract_title_cache.py`

## Testing
- `ruff check archive/extract_title_cache.py`
- `pytest -q` *(fails: AttributeError and AssertionError in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68483c8f32148326a5356c48a0b9f7f1