### PR TITLE
Move formula mixin tests

### DIFF
--- a/tests/unit/test_formula_mixin.py
+++ b/tests/unit/test_formula_mixin.py
@@ -1,8 +1,5 @@
-import os
-import sys
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..')))
 from shared_tools.processors.mixins.formula_mixin import FormulaMixin
 
 


### PR DESCRIPTION
## Summary
- relocate formula mixin tests into main test suite
- drop path hacks inside the tests

## Testing
- `pytest -q`
- `pytest tests/unit/test_formula_mixin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68483dac4b6083269a3f12726737c292