### PR TITLE
Align CLI docs and parity matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ Launch the application with offscreen rendering:
 HEADLESS=1 python app/main.py
 ```
 
+## Command Line Interface
+
+Several CLI tools accompany the GUI for scripted or headless usage. The main
+entry points live in `CorpusBuilderApp/cli.py` and `cli/execute_from_config.py`.
+See the [full CLI usage](docs/user_guide.md#using-the-cli) for details.
+
+Key commands include:
+
+- `export-corpus` – archive a corpus for distribution
+- `diff-corpus` – compare two corpus profile JSON files
+- Pipeline execution via `execute_from_config.py`
+
+Useful flags:
+
+- `--version` – print the application version
+- `--matrix` – show CLI and GUI feature parity
+
 ## License
 
 This project is proprietary and all rights are reserved by Bored AI Labs.

--- a/docs/cli_vs_gui_matrix.md
+++ b/docs/cli_vs_gui_matrix.md
@@ -13,6 +13,10 @@ The table below outlines which parts of the project are available via command-li
 | Theme and notification settings | ❌ | ✅ |
 | Configuration management | ✅ (via YAML) | ✅ (via settings tabs) |
 | View logs | ✅ (console) | ✅ (dedicated tab) |
-| Start individual collectors with custom arguments | ✅ | ✅ (through UI forms) |
+| Start individual collectors with custom arguments | ✅ | ❌ |
+| diff-corpus command | ✅ | ❌ |
+| export-corpus command | ✅ | ❌ |
+| --matrix option | ✅ | ❌ |
+| --version option | ✅ | ❌ |
 
 Use the command-line tools for headless batch operations or automation scripts. Launch the GUI for an interactive experience with corpus management, analytics and visual feedback.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -56,15 +56,30 @@ The project also provides command-line tools. For example, export a corpus:
 ```bash
 python CorpusBuilderApp/cli.py export-corpus --corpus-dir data/corpus --output-dir data/exports
 ```
+To compare corpus profiles use:
+```bash
+python CorpusBuilderApp/cli.py diff-corpus --profile-a snapshot1.json --profile-b snapshot2.json
+```
 You can run collectors and processors headlessly with `cli/execute_from_config.py`:
 ```bash
 python cli/execute_from_config.py --config path/to/config.yaml --run-all
 ```
 
+Use `--version` to print the application version or `--matrix` to see which
+features are available in the CLI versus the GUI:
+```bash
+python CorpusBuilderApp/cli.py --version
+python CorpusBuilderApp/cli.py --matrix
+```
+The `--version` flag outputs the package version number. The `--matrix` flag
+prints a table comparing CLI commands to GUI actions.
+See [CLI vs GUI feature matrix](cli_vs_gui_matrix.md) for details.
+
 ## Exporting the Corpus
 Create a versioned ZIP archive with manifest using the CLI:
 ```bash
 python CorpusBuilderApp/cli.py export-corpus --corpus-dir data/corpus --output-dir data/exports
+python CorpusBuilderApp/cli.py export-corpus --corpus-dir data/corpus --output-dir exports/ --version-tag v1.2.0
 ```
 If the Dashboard is open, you can also trigger an export from the **Tools** or **Corpus Manager** tab.
 


### PR DESCRIPTION
## Summary
- fix CLI vs GUI parity matrix in docs
- document command line interface in README
- expand CLI usage section in user guide

## Testing
- `pytest -q` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684840230f6c832680743c4900fc1aab