### PR TITLE
Safe threaded dependency updates

### DIFF
--- a/CorpusBuilderApp/shared_tools/services/dependency_update_service.py
+++ b/CorpusBuilderApp/shared_tools/services/dependency_update_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import Optional
+
+from PySide6.QtCore import QObject, QThread, Signal as pyqtSignal
+
+from upgrade_dependencies import upgrade_package, UPGRADES
+
+
+class DependencyUpdateThread(QThread):
+    """Worker thread to run dependency upgrades."""
+
+    progress = pyqtSignal(int, str)
+    finished = pyqtSignal()
+    error = pyqtSignal(str)
+
+    def __init__(self, dry_run: bool = False, parent: Optional[QObject] = None) -> None:
+        super().__init__(parent)
+        self.dry_run = dry_run
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def run(self) -> None:  # pragma: no cover - runtime thread
+        total = len(UPGRADES)
+        try:
+            for i, (pkg, ver) in enumerate(UPGRADES, start=1):
+                if self.isInterruptionRequested():
+                    return
+                if self.dry_run:
+                    msg = f"Would upgrade {pkg} to {ver}"
+                else:
+                    upgrade_package(pkg, ver)
+                    msg = f"Upgraded {pkg} to {ver}"
+                self.progress.emit(int(i / total * 100), msg)
+            if not self.dry_run:
+                with open("CorpusBuilderApp/requirements.txt", "w", encoding="utf-8") as fh:
+                    subprocess.run(["pip", "freeze"], stdout=fh, check=True)
+            self.finished.emit()
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.error("Dependency update failed: %s", exc)
+            self.error.emit(str(exc))
+
+
+class DependencyUpdateService(QObject):
+    """Service interface for running dependency updates."""
+
+    dependency_update_started = pyqtSignal()
+    dependency_update_progress = pyqtSignal(int, str)
+    dependency_update_completed = pyqtSignal()
+    dependency_update_failed = pyqtSignal(str)
+
+    def __init__(self, parent: Optional[QObject] = None) -> None:
+        super().__init__(parent)
+        self._thread: DependencyUpdateThread | None = None
+
+    # ------------------------------------------------------------------
+    def start_update(self, dry_run: bool = False) -> bool:
+        """Begin the dependency update in a background thread."""
+        if self._thread and self._thread.isRunning():
+            return False
+        self._thread = DependencyUpdateThread(dry_run, self)
+        self._thread.progress.connect(self.dependency_update_progress.emit)
+        self._thread.finished.connect(self._on_finished)
+        self._thread.error.connect(self._on_error)
+        self.dependency_update_started.emit()
+        self._thread.start()
+        return True
+
+    # ------------------------------------------------------------------
+    def _on_finished(self) -> None:
+        self.dependency_update_completed.emit()
+        self._thread = None
+
+    # ------------------------------------------------------------------
+    def _on_error(self, msg: str) -> None:
+        self.dependency_update_failed.emit(msg)
+        self._thread = None

--- a/CorpusBuilderApp/tests/unit/test_dependency_update_service.py
+++ b/CorpusBuilderApp/tests/unit/test_dependency_update_service.py
@@ -1,0 +1,48 @@
+import types
+import sys
+
+import pytest
+
+from shared_tools.services import dependency_update_service as dservice
+
+class DummySignal:
+    def __init__(self):
+        self._slots = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+
+    def emit(self, *args):
+        for s in list(self._slots):
+            s(*args)
+
+class DummyThread:
+    def __init__(self, dry_run=False, parent=None):
+        self.progress = DummySignal()
+        self.finished = DummySignal()
+        self.error = DummySignal()
+        self.dry_run = dry_run
+
+    def isRunning(self):
+        return False
+
+    def start(self):  # simulate immediate run
+        total = len(dservice.UPGRADES)
+        for i, (pkg, ver) in enumerate(dservice.UPGRADES, start=1):
+            msg = f"Would upgrade {pkg} to {ver}" if self.dry_run else f"Upgraded {pkg} to {ver}"
+            self.progress.emit(int(i / total * 100), msg)
+        self.finished.emit()
+
+def test_service_dry_run(monkeypatch):
+    monkeypatch.setattr(dservice, "DependencyUpdateThread", DummyThread)
+    service = dservice.DependencyUpdateService()
+    # replace Qt signals with dummy versions
+    service.dependency_update_progress = DummySignal()
+    service.dependency_update_completed = DummySignal()
+    progress = []
+    completed = []
+    service.dependency_update_progress.connect(lambda p, m: progress.append((p, m)))
+    service.dependency_update_completed.connect(lambda: completed.append(True))
+    assert service.start_update(dry_run=True)
+    assert completed
+    assert progress


### PR DESCRIPTION
## Summary
- add DependencyUpdateService for running dependency upgrades on a QThread
- hook Dashboard tab to use DependencyUpdateService with a confirmation dialog
- cover new service with a unit test

## Testing
- `PYTEST_QT_STUBS=1 pytest -q CorpusBuilderApp/tests/unit/test_dependency_update_service.py`
- `PYTEST_QT_STUBS=1 pytest -q` *(fails: test_multi_collector_flow, test_memory_usage_monitoring, test_run_collectors_from_config)*

------
https://chatgpt.com/codex/tasks/task_e_684844056ca48326bb77102596067d27