### PR TITLE
Add corpus validator integration

### DIFF
--- a/CorpusBuilderApp/app/main_window.py
+++ b/CorpusBuilderApp/app/main_window.py
@@ -160,7 +160,9 @@ class CryptoCorpusMainWindow(QMainWindow):
             self.tab_widget.addTab(self.processors_tab, "⚙️ Processors")
             # Corpus Manager tab
             self.logger.debug("Initializing CorpusManagerTab...")
-            self.corpus_manager_tab = CorpusManagerTab(self.config)
+            self.corpus_manager_tab = CorpusManagerTab(
+                self.config, activity_log_service=self.activity_log_service
+            )
             self.logger.debug("CorpusManagerTab initialized successfully")
             self.tab_widget.addTab(self.corpus_manager_tab, "📁 Corpus Manager")
             # Balancer tab

--- a/CorpusBuilderApp/shared_tools/services/corpus_validator_service.py
+++ b/CorpusBuilderApp/shared_tools/services/corpus_validator_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional, List, Dict
+
+from PySide6.QtCore import QObject, Signal as pyqtSignal
+
+from shared_tools.project_config import ProjectConfig
+from tools.check_corpus_structure import check_corpus_structure
+
+
+class _LogCaptureHandler(logging.Handler):
+    """Simple logging handler to capture log records."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: List[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - simple
+        self.records.append(record)
+
+
+class CorpusValidatorService(QObject):
+    """Service wrapper around ``check_corpus_structure`` utility."""
+
+    validation_started = pyqtSignal()
+    validation_completed = pyqtSignal(dict)
+    validation_failed = pyqtSignal(str)
+
+    def __init__(
+        self,
+        project_config: ProjectConfig,
+        activity_log_service: Optional[object] = None,
+        parent: Optional[QObject] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.project_config = project_config
+        self.activity_log_service = activity_log_service
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.results: Dict[str, object] = {}
+
+    # ------------------------------------------------------------------
+    def validate_structure(self) -> None:
+        """Run corpus structure validation and emit results."""
+        self.validation_started.emit()
+        handler = _LogCaptureHandler()
+        target_logger = logging.getLogger("tools.check_corpus_structure")
+        target_logger.addHandler(handler)
+        prev_level = target_logger.level
+        target_logger.setLevel(logging.INFO)
+        try:
+            check_corpus_structure(self.project_config)
+            messages = [
+                {"level": r.levelname.lower(), "message": r.getMessage()}
+                for r in handler.records
+            ]
+            self.results = {"messages": messages}
+            self.validation_completed.emit(self.results)
+            if self.activity_log_service:
+                for msg in messages:
+                    try:
+                        self.activity_log_service.log(
+                            "CorpusValidator",
+                            msg["message"],
+                            {"level": msg["level"]},
+                        )
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+        except Exception as exc:  # pragma: no cover - runtime guard
+            self.logger.error("Validation failed: %s", exc)
+            if self.activity_log_service:
+                try:
+                    self.activity_log_service.log(
+                        "CorpusValidator", "Validation failed", {"error": str(exc)}
+                    )
+                except Exception:
+                    pass
+            self.validation_failed.emit(str(exc))
+        finally:
+            target_logger.removeHandler(handler)
+            target_logger.setLevel(prev_level)
+

--- a/CorpusBuilderApp/tests/unit/test_corpus_validator_service.py
+++ b/CorpusBuilderApp/tests/unit/test_corpus_validator_service.py
@@ -1,0 +1,54 @@
+import types
+from pathlib import Path
+
+from PySide6.QtCore import QObject
+
+from shared_tools.services.corpus_validator_service import CorpusValidatorService
+
+
+class DummyCfg:
+    def __init__(self, base: Path):
+        self.base = base
+        self.domains = {"a": {}, "b": {}}
+
+    def get_corpus_dir(self):
+        return str(self.base)
+
+    def get_raw_dir(self):
+        return str(self.base / "raw")
+
+    def get_processed_dir(self):
+        return str(self.base / "processed")
+
+    def get_metadata_dir(self):
+        return str(self.base / "metadata")
+
+    def get_logs_dir(self):
+        return str(self.base / "logs")
+
+    def get(self, key, default=None):
+        if key == "domains":
+            return self.domains
+        return default
+
+
+def test_validation_emits_results(tmp_path, qapp):
+    for sub in ["raw", "processed", "metadata", "logs"]:
+        (tmp_path / sub).mkdir()
+    cfg = DummyCfg(tmp_path)
+    service = CorpusValidatorService(cfg)
+    service.validate_structure()
+    assert "messages" in service.results
+
+
+def test_validation_failure_emits_error(monkeypatch, tmp_path, qapp):
+    cfg = DummyCfg(tmp_path)
+    service = CorpusValidatorService(cfg)
+    monkeypatch.setattr(
+        "shared_tools.services.corpus_validator_service.check_corpus_structure",
+        lambda _cfg: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    service.validate_structure()
+    assert service.results == {}
+
+

--- a/tests/ui/test_corpus_manager_tab.py
+++ b/tests/ui/test_corpus_manager_tab.py
@@ -60,6 +60,8 @@ def minimal_setup_ui(self):
     self.batch_move_btn.clicked.connect(self.batch_move_files)
     self.batch_delete_btn = types.SimpleNamespace(clicked=DummySignal())
     self.batch_delete_btn.clicked.connect(self.batch_delete_files)
+    self.validate_structure_btn = types.SimpleNamespace(clicked=DummySignal())
+    self.validate_structure_btn.clicked.connect(self.validate_corpus_structure)
 
 
 class DummyMessageBox:


### PR DESCRIPTION
## Summary
- implement `CorpusValidatorService` for corpus structure checks
- hook validator service into `CorpusManagerTab`
- expose service via `MainWindow`
- update test scaffolding for new button
- add unit tests for validator service

## Testing
- `ruff check . --exclude CorpusBuilderApp/RUN_COLLECTORS_HERE.ipynb` *(fails: `PySide6.QtGui.QBrush imported but unused`)*
- `PYTEST_QT_STUBS=1 pytest CorpusBuilderApp/tests/unit/test_corpus_validator_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68484420f7ac83269308328416a19e62