### PR TITLE
Document CLI execution flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ Useful flags:
 
 - `--version` – print the application version
 - `--matrix` – show CLI and GUI feature parity
+- `--collect` – run enabled collectors
+- `--extract` – run enabled processors
+- `--balance` – run the corpus balancer
+- `--preview-only` – list modules without executing them
+
+Example preview run:
+```bash
+python cli/execute_from_config.py --config path/to/config.yaml \
+    --collect --extract --balance --preview-only
+```
 
 ## License
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -60,9 +60,22 @@ To compare corpus profiles use:
 ```bash
 python CorpusBuilderApp/cli.py diff-corpus --profile-a snapshot1.json --profile-b snapshot2.json
 ```
-You can run collectors and processors headlessly with `cli/execute_from_config.py`:
+You can run collectors, processors and the corpus balancer headlessly with
+`cli/execute_from_config.py`:
 ```bash
 python cli/execute_from_config.py --config path/to/config.yaml --run-all
+```
+Additional flags let you control which phases execute:
+
+- `--collect` – run enabled collectors
+- `--extract` – run enabled processors
+- `--balance` – run the corpus balancer
+- `--preview-only` – show selected modules without running them
+
+Preview all phases without executing them:
+```bash
+python cli/execute_from_config.py --config path/to/config.yaml \
+    --collect --extract --balance --preview-only
 ```
 
 Use `--version` to print the application version or `--matrix` to see which


### PR DESCRIPTION
## Summary
- document collect/extract/balance/preview-only flags in README
- expand the CLI usage docs with flag explanations and example

## Testing
- `pytest -q`
- `pytest -m "not integration" -q`
- `ruff check .` *(fails: many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_684845f956d083268ecbfe08c70c271a