### PR TITLE
Fix CLI args test

### DIFF
--- a/tests/unit/test_cli_execute.py
+++ b/tests/unit/test_cli_execute.py
@@ -2,5 +2,6 @@ from cli.execute_from_config import parse_args
 
 
 def test_parse_args_defaults():
-    args = parse_args([])
-    assert args.dry_run is False
+    """Verify default argument values when required options are provided."""
+    args = parse_args(["--config", "dummy.yml"])
+    assert args.preview_only is False


### PR DESCRIPTION
## Summary
- update CLI execute unit test to assert `args.preview_only`
- provide a required dummy config path when parsing args

## Testing
- `pytest tests/unit/test_cli_execute.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684845f8712c83268c95a2b1dc9aeb52