### PR TITLE
Add danger style to default reset button

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/configuration_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/configuration_tab.py
@@ -70,6 +70,7 @@ class ConfigurationTab(QWidget):
         buttons_layout.addWidget(self.reset_btn)
         
         self.default_btn = QPushButton("Reset to Defaults")
+        self.default_btn.setObjectName("danger")
         self.default_btn.clicked.connect(self.load_default_config)
         buttons_layout.addWidget(self.default_btn)
         


### PR DESCRIPTION
## Summary
- make the 'Reset to Defaults' button share the danger style

## Testing
- `pytest -q`
- `HEADLESS=1 python CorpusBuilderApp/app/main.py` *(fails: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68484744c96083269e9a2ad469d18f50