### PR TITLE
Enforce virtualenv for dependency upgrades

### DIFF
--- a/CorpusBuilderApp/tests/unit/test_dependency_update_service.py
+++ b/CorpusBuilderApp/tests/unit/test_dependency_update_service.py
@@ -35,6 +35,7 @@ class DummyThread:
 
 def test_service_dry_run(monkeypatch):
     monkeypatch.setattr(dservice, "DependencyUpdateThread", DummyThread)
+    monkeypatch.setattr(dservice, "is_virtual_env", lambda: True)
     service = dservice.DependencyUpdateService()
     # replace Qt signals with dummy versions
     service.dependency_update_progress = DummySignal()
@@ -46,3 +47,14 @@ def test_service_dry_run(monkeypatch):
     assert service.start_update(dry_run=True)
     assert completed
     assert progress
+
+
+def test_service_requires_virtualenv(monkeypatch):
+    monkeypatch.setattr(dservice, "DependencyUpdateThread", DummyThread)
+    monkeypatch.setattr(dservice, "is_virtual_env", lambda: False)
+    service = dservice.DependencyUpdateService()
+    service.dependency_update_failed = DummySignal()
+    received = []
+    service.dependency_update_failed.connect(lambda msg: received.append(msg))
+    assert service.start_update(dry_run=True) is False
+    assert received

--- a/CorpusBuilderApp/upgrade_dependencies.py
+++ b/CorpusBuilderApp/upgrade_dependencies.py
@@ -1,4 +1,6 @@
 import subprocess
+import sys
+import os
 
 # List of packages to upgrade (package, safe_version)
 UPGRADES = [
@@ -11,16 +13,27 @@ UPGRADES = [
     # Add more as needed
 ]
 
+
+def is_virtual_env() -> bool:
+    """Return True if running inside a virtual environment."""
+    return (
+        sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+        or os.environ.get("VIRTUAL_ENV") is not None
+    )
+
 def upgrade_package(pkg, version):
     print(f"Upgrading {pkg} to {version} ...")
-    subprocess.run(["pip", "install", f"{pkg}>={version}"], check=True)
+    subprocess.run([sys.executable, "-m", "pip", "install", f"{pkg}>={version}"], check=True)
 
 def main():
+    if not is_virtual_env():
+        print("Error: virtual environment required for dependency upgrades.", file=sys.stderr)
+        return 1
     for pkg, version in UPGRADES:
         upgrade_package(pkg, version)
     # Freeze the new requirements
     with open("CorpusBuilderApp/requirements.txt", "w") as f:
-        subprocess.run(["pip", "freeze"], stdout=f, check=True)
+        subprocess.run([sys.executable, "-m", "pip", "freeze"], stdout=f, check=True)
     print("All packages upgraded and requirements.txt updated.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- run pip via `sys.executable -m pip`
- add `is_virtual_env` helper to abort when not in venv
- prevent `DependencyUpdateService` from running outside a venv
- test that updates fail without a venv

## Testing
- `PYTEST_QT_STUBS=1 pytest CorpusBuilderApp/tests/unit tests/unit -q` *(fails: ImportError: cannot import name 'QtWidgets' from '<unknown module name>')*

------
https://chatgpt.com/codex/tasks/task_e_68484a8057508326b120380affa893cb