### PR TITLE
Add optional metadata validation

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
@@ -389,6 +389,9 @@ class CorpusManagerTab(QWidget):
         self.batch_edit_btn.clicked.connect(self.open_batch_metadata_editor)
         other_buttons_layout.addWidget(self.batch_edit_btn)
 
+        self.validate_metadata_cb = QCheckBox("Validate Metadata")
+        other_buttons_layout.addWidget(self.validate_metadata_cb)
+
         self.validate_structure_btn = QPushButton("Validate Structure")
         self.validate_structure_btn.clicked.connect(self.validate_corpus_structure)
         other_buttons_layout.addWidget(self.validate_structure_btn)
@@ -913,7 +916,9 @@ class CorpusManagerTab(QWidget):
 
     def validate_corpus_structure(self) -> None:
         """Trigger corpus structure validation via the service."""
-        self.validator_service.validate_structure()
+        self.validator_service.validate_structure(
+            validate_metadata=self.validate_metadata_cb.isChecked()
+        )
 
     def show_validation_results(self, results: dict) -> None:
         messages = results.get("messages", [])

--- a/CorpusBuilderApp/shared_tools/services/corpus_validator_service.py
+++ b/CorpusBuilderApp/shared_tools/services/corpus_validator_service.py
@@ -40,7 +40,7 @@ class CorpusValidatorService(QObject):
         self.results: Dict[str, object] = {}
 
     # ------------------------------------------------------------------
-    def validate_structure(self) -> None:
+    def validate_structure(self, validate_metadata: bool = False) -> None:
         """Run corpus structure validation and emit results."""
         self.validation_started.emit()
         handler = _LogCaptureHandler()
@@ -49,7 +49,7 @@ class CorpusValidatorService(QObject):
         prev_level = target_logger.level
         target_logger.setLevel(logging.INFO)
         try:
-            check_corpus_structure(self.project_config)
+            check_corpus_structure(self.project_config, validate_metadata=validate_metadata)
             messages = [
                 {"level": r.levelname.lower(), "message": r.getMessage()}
                 for r in handler.records


### PR DESCRIPTION
## Summary
- validate metadata files in `check_corpus_structure`
- pass optional flag through `CorpusValidatorService`
- add UI checkbox for metadata validation
- test new validation logic and service flag

## Testing
- `PYTEST_QT_STUBS=1 pytest -c pytest.ini CorpusBuilderApp/tests/unit/test_corpus_validator_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68484c0366188326976c0b02788cf91c