### PR TITLE
Implement config refresh logic in processor wrappers

### DIFF
--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/base_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/base_extractor_wrapper.py
@@ -541,5 +541,27 @@ class BaseExtractorWrapper(BaseWrapper):
         return True
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('base_extractor') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/batch_nonpdf_extractor_enhanced_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/batch_nonpdf_extractor_enhanced_wrapper.py
@@ -338,5 +338,27 @@ class BatchNonPDFExtractorEnhancedWrapper(BaseWrapper, ProcessorWrapperMixin):
         return self.worker is not None and self.worker.isRunning()
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('batch_nonpdf_extractor_enhanced') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/batch_text_extractor_enhanced_prerefactor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/batch_text_extractor_enhanced_prerefactor_wrapper.py
@@ -736,5 +736,27 @@ class BatchTextExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
         return self.worker is not None and self.worker.isRunning()
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('batch_text_extractor_enhanced_prerefactor') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/chart_image_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/chart_image_extractor_wrapper.py
@@ -75,8 +75,30 @@ class ChartImageExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
         )
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('chart_extraction') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)
 
 class ChartExtractorWorkerThread(QThread):
     """Worker thread for chart extraction processing."""

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/corpus_balancer_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/corpus_balancer_wrapper.py
@@ -213,5 +213,27 @@ class CorpusBalancerWrapper(BaseWrapper, ProcessorWrapperMixin):
         self.status_updated.emit("Updated collector configs based on imbalance analysis")
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('corpus_balancer') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/corruption_detector_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/corruption_detector_wrapper.py
@@ -701,5 +701,27 @@ class CorruptionDetectorWrapper(BaseWrapper, ProcessorWrapperMixin):
         return self.worker is not None and self.worker.isRunning()
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('corruption') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/deduplicate_nonpdf_outputs_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/deduplicate_nonpdf_outputs_wrapper.py
@@ -649,5 +649,27 @@ class DeduplicateNonPDFOutputsWrapper(BaseWrapper, ProcessorWrapperMixin):
         return self.worker is not None and self.worker.isRunning()
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('deduplicate_nonpdf_outputs') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/deduplicator_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/deduplicator_wrapper.py
@@ -91,8 +91,30 @@ class DeduplicatorWrapper(BaseWrapper, ProcessorWrapperMixin):
         )
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('deduplicator') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)
 
     @pyqtSlot()
     def start_deduplication(self):

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domain_classifier_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domain_classifier_wrapper.py
@@ -82,8 +82,30 @@ class DomainClassifierWrapper(BaseWrapper, ProcessorWrapperMixin):
         )
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('domain_classifier') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)
 
 class DomainClassifierWorkerThread(QThread):
     """Worker thread for domain classification processing."""

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domainsmanager_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domainsmanager_wrapper.py
@@ -1019,5 +1019,27 @@ class DomainsManagerWrapper(BaseWrapper, ProcessorWrapperMixin):
         return self.worker is not None and self.worker.isRunning()
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('domainsmanager') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/financial_symbol_processor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/financial_symbol_processor_wrapper.py
@@ -83,8 +83,30 @@ class FinancialSymbolProcessorWrapper(BaseWrapper, ProcessorWrapperMixin):
         )
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('financial_symbol_processor') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)
 
 class FinancialSymbolWorkerThread(QThread):
     """Worker thread for financial symbol extraction processing."""

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/formula_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/formula_extractor_wrapper.py
@@ -75,8 +75,30 @@ class FormulaExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
         )
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('formula_extraction') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)
 
 class FormulaExtractorWorkerThread(QThread):
     """Worker thread for formula extraction processing."""

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/language_confidence_detector_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/language_confidence_detector_wrapper.py
@@ -82,8 +82,30 @@ class LanguageConfidenceDetectorWrapper(BaseWrapper, ProcessorWrapperMixin):
         )
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('language_confidence') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)
 
 class LanguageDetectorWorkerThread(QThread):
     """Worker thread for language detection processing."""

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/machine_translation_detector_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/machine_translation_detector_wrapper.py
@@ -83,8 +83,30 @@ class MachineTranslationDetectorWrapper(BaseWrapper, ProcessorWrapperMixin):
         )
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('machine_translation') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)
 
 class MTDetectorWorkerThread(QThread):
     """Worker thread for machine translation detection processing."""

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/monitor_progress_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/monitor_progress_wrapper.py
@@ -810,5 +810,27 @@ class MonitorProgressWrapper(BaseWrapper, ProcessorWrapperMixin):
             json.dump(rows, f, ensure_ascii=False, indent=2)
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('monitor_progress') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/pdf_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/pdf_extractor_wrapper.py
@@ -150,5 +150,27 @@ class PDFExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
         return {"files_processed": 0, "ocr_used_count": 0}
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('pdf_extractor') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/quality_control_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/quality_control_wrapper.py
@@ -89,8 +89,30 @@ class QualityControlWrapper(BaseWrapper, ProcessorWrapperMixin):
         pass
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('quality_control') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)
 
 class QCWorkerThread(QThread):
     """Worker thread for quality control processing."""

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/text_extractor_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/text_extractor_wrapper.py
@@ -135,5 +135,27 @@ class TextExtractorWrapper(BaseWrapper, ProcessorWrapperMixin):
         return {"formats_processed": {}}
 
     def refresh_config(self):
-        """Reload parameters from ``self.config``. Placeholder for future use."""
-        pass
+        """Reload parameters from ``self.config``."""
+        cfg = {}
+        if hasattr(self.config, 'get_processor_config'):
+            cfg = self.config.get_processor_config('text_extractor') or {}
+        for k, v in cfg.items():
+            method = f'set_{k}'
+            if hasattr(self, method):
+                try:
+                    getattr(self, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via wrapper', k)
+            if hasattr(self.processor, method):
+                try:
+                    getattr(self.processor, method)(v)
+                    continue
+                except Exception:
+                    self.logger.debug('Failed to apply %s via processor', k)
+            if hasattr(self.processor, k):
+                setattr(self.processor, k, v)
+            elif hasattr(self, k):
+                setattr(self, k, v)
+        if cfg and hasattr(self, 'configuration_changed'):
+            self.configuration_changed.emit(cfg)


### PR DESCRIPTION
## Summary
- hook refresh_config in every processor UI wrapper
- load per-processor options using `get_processor_config`
- apply options to wrapper or processor via setters or attributes

## Testing
- `pytest -q` *(fails: AttributeError in collectors; memory info missing)*

------
https://chatgpt.com/codex/tasks/task_e_684853a580ec8326bc00a44346008d1b