### PR TITLE
Add auto-fix and integrity options to corpus validation

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -117,7 +117,9 @@ Use **Tools → Import Corpus** to load a previously exported ZIP archive. The s
 
 - **check_corpus_structure.py** – validate the directories defined in your
   `ProjectConfig`. Run it with `--config path/to/config.yaml` to check that the
-  raw, processed, metadata and logs folders exist and are writable.
+  raw, processed, metadata and logs folders exist and are writable. Use
+  `--auto-fix` to create any missing directories and `--check-integrity` to
+  scan sample files for corruption.
 
 ## Troubleshooting
 - If a configuration fails to load, check the YAML syntax and file paths.


### PR DESCRIPTION
## Summary
- extend `check_corpus_structure` with `auto_fix` and `check_integrity`
- expose new options through `CorpusValidatorService`
- update CLI and docs for the additional flags
- adjust validator service tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68485d94c4888326b2ec8f6936ea3c8c