### PR TITLE
Add tooling commands and prototype organization

### DIFF
--- a/CorpusBuilderApp/shared_tools/utils/config_sync.py
+++ b/CorpusBuilderApp/shared_tools/utils/config_sync.py
@@ -1,9 +1,5 @@
-"""
-Config Sync Script
-Synchronizes domain_config.py allocations and properties with balancer_config.py target_weights and fields.
-Backs up the original domain_config.py before modifying.
-Supports safe (default) and force modes.
-"""
+# ⚠️ Developer-only script.
+# Syncs domain_config.py with balancer_config.yaml – use with caution.
 import sys
 import shutil
 from pathlib import Path

--- a/tools/gen_config_schema.py
+++ b/tools/gen_config_schema.py
@@ -1,7 +1,5 @@
-"""
-Module: gen_config_schema
-Purpose: Generate a default ProjectConfig YAML schema.
-"""
+# Utility script to generate a sample ProjectConfig YAML.
+# Not used in runtime – useful for onboarding and CI.
 
 from shared_tools.project_config import ProjectConfig
 import yaml

--- a/tools/prototypes/new_source_collector.py
+++ b/tools/prototypes/new_source_collector.py
@@ -1,4 +1,4 @@
-# PROTOTYPE: Not integrated into app. Placeholder only.
+# ⚠️ Placeholder for future collector. Not used in app.
 # sources/specific_collectors/new_source_collector.py
 from shared_tools.collectors.web_collector import WebCollector
 

--- a/tools/prototypes/ocr_formula_test.py
+++ b/tools/prototypes/ocr_formula_test.py
@@ -1,4 +1,4 @@
-# PROTOTYPE: Not integrated into app. Placeholder only.
+# ⚠️ Prototype script. Not integrated. Used for OCR testing only.
 import fitz
 from PIL import Image
 import pytesseract


### PR DESCRIPTION
## Summary
- integrate check-corpus and generate-default-config commands
- expose optional sync-config developer tool
- document standalone tooling scripts
- move prototype utilities into tools/prototypes

## Testing
- `pytest -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_684862b30eac83268ad0aee038c349a8