### PR TITLE
Fix imports and variable initialization

### DIFF
--- a/CorpusBuilderApp/app/ui/dialogs/collector_config_dialog.py
+++ b/CorpusBuilderApp/app/ui/dialogs/collector_config_dialog.py
@@ -11,7 +11,7 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QPushButton,
 )
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QObject
 
 from app.ui.widgets.card_wrapper import CardWrapper
 from app.ui.widgets.status_dot import StatusDot

--- a/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
@@ -23,6 +23,7 @@ from PySide6.QtWidgets import (
     QFileSystemModel,
     QScrollArea,
     QFrame,
+    QGroupBox,
 )
 from PySide6.QtGui import QAction, QStandardItemModel, QStandardItem, QDragEnterEvent, QDropEvent, QIcon
 from PySide6.QtCore import (

--- a/CorpusBuilderApp/shared_tools/processors/batch_nonpdf_extractor_enhanced.py
+++ b/CorpusBuilderApp/shared_tools/processors/batch_nonpdf_extractor_enhanced.py
@@ -237,6 +237,7 @@ def process_nonpdf_file_enhanced(file_path: str, args: argparse.Namespace) -> Op
         formula_extractor = FormulaExtractor()
         symbol_processor = FinancialSymbolProcessor()
         academic_processor = AcademicPaperProcessor()
+        symbol_glossary = None
         
         # Special handling for code files
         is_code_file = ext in ['.py', '.ipynb']

--- a/CorpusBuilderApp/shared_tools/processors/batch_text_extractor_enhanced_prerefactor.py
+++ b/CorpusBuilderApp/shared_tools/processors/batch_text_extractor_enhanced_prerefactor.py
@@ -143,6 +143,8 @@ from .financial_symbol_processor import FinancialSymbolProcessor, AcademicPaperP
 from ..utils.domain_utils import get_domain_for_file
 from ..utils.pdf_safe_open import safe_open_pdf
 from ..utils.metadata_normalizer import main as normalize_directory
+from shared_tools.processors.domain_classifier import DomainClassifier
+from shared_tools.utils.metadata_normalizer import normalize_metadata
 from .corruption_detector import detect_corruption
 from .language_confidence_detector import detect_language_confidence
 from .machine_translation_detector import detect_machine_translation

--- a/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domainsmanager_wrapper.py
+++ b/CorpusBuilderApp/shared_tools/ui_wrappers/processors/domainsmanager_wrapper.py
@@ -7,9 +7,9 @@ import os
 import json
 from typing import Dict, List, Optional, Any, Set
 from PySide6.QtCore import QObject, QThread, Signal as pyqtSignal, Slot as pyqtSlot, QMutex
-from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QPushButton, 
-                           QProgressBar, QLabel, QTextEdit, QFileDialog, QCheckBox, 
-                           QSpinBox, QGroupBox, QGridLayout, QComboBox, QListWidget,
+from PySide6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QPushButton,
+                           QProgressBar, QLabel, QTextEdit, QFileDialog, QCheckBox,
+                           QSpinBox, QDoubleSpinBox, QGroupBox, QGridLayout, QComboBox, QListWidget,
                            QSplitter, QTabWidget, QTableWidget, QTableWidgetItem,
                            QHeaderView, QLineEdit, QTreeWidget, QTreeWidgetItem)
 from shared_tools.ui_wrappers.base_wrapper import BaseWrapper

--- a/tests/ui/test_corpus_manager_tab.py
+++ b/tests/ui/test_corpus_manager_tab.py
@@ -1,4 +1,5 @@
 import types
+import os
 import pytest
 from PySide6.QtCore import QObject, Signal as pyqtSignal, QDir
 from PySide6.QtWidgets import QPushButton


### PR DESCRIPTION
## Summary
- add missing imports across UI widgets and tests
- ensure domain classifier utils imported in text extractor
- include QGroupBox and QDoubleSpinBox widgets
- initialize `symbol_glossary` before use

## Testing
- `python -m compileall -q .`
- `pytest -k "" -q` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684863267c008326b81fba1d95db601c