### PR TITLE
Cleanup helpers and unify dashboard charts

### DIFF
--- a/CorpusBuilderApp/app/helpers/chart_manager.py
+++ b/CorpusBuilderApp/app/helpers/chart_manager.py
@@ -3,10 +3,10 @@ Chart Manager for Crypto Corpus Builder
 Centralizes chart styling, colors, and creation for consistency across the application.
 """
 
-from PySide6.QtGui import QColor, QPainter, QBrush
+from PySide6.QtGui import QColor, QPainter
 from PySide6.QtCharts import QChart, QChartView, QPieSeries, QBarSeries, QBarSet, QBarCategoryAxis, QValueAxis
 from PySide6.QtCore import Qt
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 
 
 class ChartManager:
@@ -236,24 +236,18 @@ class ChartManager:
         """Get consistent color for a status"""
         return self.STATUS_COLORS.get(status.lower(), self.BRAND_COLORS['primary'])
     
-    def update_chart_theme(self, chart_view: QChartView):
-        """Update an existing chart's theme"""
-        chart = chart_view.chart()
+    def apply_chart_theme(self, chart: QChart) -> None:
+        """Apply the current theme to a chart instance."""
         chart.setBackgroundBrush(QColor(self.background_color))
         chart.setTitleBrush(QColor(self.title_color))
-        
-        # Improve legend contrast
+
         legend = chart.legend()
         if legend:
             legend.setLabelColor(QColor(255, 255, 255))  # White text for better contrast
             legend.setBackgroundVisible(True)
-            legend.setColor(QColor(self.background_color))  # Match background
+            legend.setColor(QColor(self.background_color))
+
+    def update_chart_theme(self, chart_view: QChartView) -> None:
+        """Update an existing chart view's theme"""
+        self.apply_chart_theme(chart_view.chart())
     
-    def apply_white_legend_text(self, chart_view: QChartView):
-        """Apply white text to chart legends for better contrast"""
-        chart = chart_view.chart()
-        legend = chart.legend()
-        if legend:
-            legend.setLabelColor(QColor(255, 255, 255))  # White text
-            legend.setBackgroundVisible(True)
-            legend.setColor(QColor(self.background_color))  # Match chart background 

--- a/CorpusBuilderApp/app/helpers/crypto_utils.py
+++ b/CorpusBuilderApp/app/helpers/crypto_utils.py
@@ -1,6 +1,7 @@
-import base64
 import keyring
 from cryptography.fernet import Fernet, InvalidToken
+
+# Reserved for secure config storage (future)
 
 SERVICE_NAME = 'CryptoCorpusBuilder'
 KEYRING_KEY = 'config_encryption_key'

--- a/CorpusBuilderApp/app/helpers/theme_manager.py
+++ b/CorpusBuilderApp/app/helpers/theme_manager.py
@@ -1,7 +1,4 @@
-from PySide6.QtWidgets import QApplication, QSystemTrayIcon
-from PySide6.QtCore import QFile, QTextStream, QUrl
-from PySide6.QtMultimedia import QSoundEffect
-import os
+from PySide6.QtWidgets import QApplication
 from pathlib import Path
 
 class ThemeManager:
@@ -69,7 +66,12 @@ class ThemeManager:
                     widget.setStyleSheet(current_style)
                 widget.update()
                 widget.repaint()
-                    
+
+            # Notify widgets that support explicit theme updates
+            for widget in app.topLevelWidgets():
+                if hasattr(widget, 'update_theme'):
+                    widget.update_theme()
+
             print(f"DEBUG: Theme application completed")
             
         except Exception as e:

--- a/CorpusBuilderApp/app/ui/tabs/configuration_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/configuration_tab.py
@@ -10,7 +10,6 @@ import yaml
 from pathlib import Path
 from dotenv import load_dotenv, set_key
 from pydantic import ValidationError
-from app.helpers.crypto_utils import encrypt_value, decrypt_value
 from app.ui.widgets.section_header import SectionHeader
 from app.ui.theme.theme_constants import PAGE_MARGIN
 

--- a/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
@@ -16,7 +16,8 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt, Signal, QMargins
 from PySide6.QtGui import QColor, QPainter
 import sys
-from PySide6.QtCharts import QChart, QChartView, QPieSeries
+from PySide6.QtCharts import QPieSeries
+from app.helpers.chart_manager import ChartManager
 from datetime import datetime
 from app.ui.widgets.card_wrapper import CardWrapper
 from app.ui.widgets.section_header import SectionHeader
@@ -49,6 +50,7 @@ class DashboardTab(QWidget):
         self.activity_log_service = activity_log_service
         self.metric_labels = {}
         self.stats_service = CorpusStatsService(project_config)
+        self.chart_manager = ChartManager('dark')
         self.task_history_service = task_history_service
         self.task_queue_manager = task_queue_manager or TaskQueueManager()
         self.task_queue_manager.queue_counts_changed.connect(self.update_queue_counts)
@@ -222,7 +224,8 @@ class DashboardTab(QWidget):
 
     def create_giant_pie_chart(self, domain_data):
         from PySide6.QtCore import Qt
-        chart = QChart()
+        chart_view = self.chart_manager.create_chart_view("")
+        chart = chart_view.chart()
         chart.setBackgroundBrush(QColor('transparent'))
         chart.setMargins(QMargins(0, 0, 0, 0))
         colors = ['#22c55e', '#32B8C6', '#E68161', '#8b5cf6', '#f59e0b', '#ef4444', '#06b6d4', '#9ca3af']
@@ -237,10 +240,10 @@ class DashboardTab(QWidget):
         chart.addSeries(series)
         chart.setTitle('')
         chart.legend().setVisible(False)
-        chart_view = QChartView(chart)
         chart_view.setFixedSize(300, 300)
         chart_view.setStyleSheet('background-color: transparent; border: none;')
         chart_view.setRenderHint(QPainter.Antialiasing)
+        self.chart_manager.apply_chart_theme(chart)
         chart_container = QWidget()
         chart_container.setStyleSheet('background-color: transparent;')
         chart_layout = QVBoxLayout(chart_container)
@@ -1007,7 +1010,8 @@ class DashboardTab(QWidget):
 
     def create_large_pie_chart(self, domain_data):
         from PySide6.QtCore import Qt
-        chart = QChart()
+        chart_view = self.chart_manager.create_chart_view("")
+        chart = chart_view.chart()
         chart.setBackgroundBrush(QColor('transparent'))
         chart.setMargins(QMargins(0, 0, 0, 0))
         colors = ['#22c55e', '#32B8C6', '#E68161', '#8b5cf6', '#f59e0b', '#ef4444', '#06b6d4', '#9ca3af']
@@ -1022,10 +1026,10 @@ class DashboardTab(QWidget):
         chart.addSeries(series)
         chart.setTitle('')
         chart.legend().setVisible(False)
-        chart_view = QChartView(chart)
         chart_view.setFixedSize(220, 220)
         chart_view.setStyleSheet('background-color: transparent; border: none;')
         chart_view.setRenderHint(QPainter.Antialiasing)
+        self.chart_manager.apply_chart_theme(chart)
         chart_container = QWidget()
         chart_container.setStyleSheet('background-color: transparent;')
         chart_layout = QVBoxLayout(chart_container)
@@ -1093,7 +1097,8 @@ class DashboardTab(QWidget):
         return container
 
     def create_huge_pie_chart_up_left(self, domain_data):
-        chart = QChart()
+        chart_view = self.chart_manager.create_chart_view("")
+        chart = chart_view.chart()
         chart.setBackgroundBrush(QColor('transparent'))
         chart.setMargins(QMargins(0, 0, 0, 0))
         colors = ['#22c55e', '#32B8C6', '#E68161', '#8b5cf6', '#f59e0b', '#ef4444', '#06b6d4', '#9ca3af']
@@ -1108,10 +1113,10 @@ class DashboardTab(QWidget):
         chart.addSeries(series)
         chart.setTitle('')
         chart.legend().setVisible(False)
-        chart_view = QChartView(chart)
         chart_view.setFixedSize(480, 480)
         chart_view.setStyleSheet('background-color: transparent; border: none;')
         chart_view.setRenderHint(QPainter.Antialiasing)
+        self.chart_manager.apply_chart_theme(chart)
         chart_container = QWidget()
         chart_container.setStyleSheet('background-color: transparent;')
         chart_layout = QHBoxLayout(chart_container)


### PR DESCRIPTION
## Summary
- remove unused imports from helpers
- drop unused crypto_utils import in ConfigurationTab
- add chart manager to DashboardTab and use for pie charts
- add apply_chart_theme helper
- refresh widgets after theme change

## Testing
- `python -m py_compile CorpusBuilderApp/app/helpers/chart_manager.py CorpusBuilderApp/app/helpers/theme_manager.py CorpusBuilderApp/app/helpers/crypto_utils.py CorpusBuilderApp/app/ui/tabs/dashboard_tab.py CorpusBuilderApp/app/ui/tabs/configuration_tab.py`
- `pytest -q` *(fails: AttributeError: 'list' object has no attribute 'to_csv')*

------
https://chatgpt.com/codex/tasks/task_e_6848636137c0832691184daa4536746f