### PR TITLE
Integrate domain config sync into CLI

### DIFF
--- a/CorpusBuilderApp/cli.py
+++ b/CorpusBuilderApp/cli.py
@@ -180,13 +180,34 @@ def main(argv: list[str] | None = None) -> int:
             help="Output path for generated YAML",
         )
         gen_args = gen_parser.parse_args(argv[1:])
+
         from shared_tools.project_config import ProjectConfig
         import yaml
 
         default = ProjectConfig.create_default_config_object()
         with open(gen_args.output, "w", encoding="utf-8") as out:
             yaml.safe_dump(default, out, sort_keys=False)
-        print(f"Config written to {gen_args.output}")
+        print(f"✅ Default config saved to {gen_args.output}")
+        return 0
+
+    if argv and argv[0] == "sync-domain-config":
+        sync_parser = argparse.ArgumentParser(
+            prog="sync-domain-config",
+            description="Sync domain_config.py with balancer_config.yaml",
+        )
+        sync_parser.add_argument("--config", required=True, help="Path to balancer_config.yaml")
+        sync_parser.add_argument("--force-sync", action="store_true", help="Force replace all properties")
+        sync_args = sync_parser.parse_args(argv[1:])
+
+        from shared_tools.utils.config_sync import sync_domains
+
+        try:
+            log_entries = sync_domains(force_sync=sync_args.force_sync)
+            for entry in log_entries:
+                print(entry)
+        except Exception as exc:  # pragma: no cover - developer tool
+            print(f"[ERROR] {exc}")
+            return 1
         return 0
 
     if argv and argv[0] == "sync-config":

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Key commands include:
 
 - `export-corpus` – archive a corpus for distribution
 - `diff-corpus` – compare two corpus profile JSON files
+- `generate-default-config` – write a template ProjectConfig YAML
+- `sync-domain-config` – update domain_config.py from balancer_config
 - Pipeline execution via `execute_from_config.py`
 
 For a complete comparison of what the command line and GUI each offer, see [docs/cli_vs_gui_matrix.md](docs/cli_vs_gui_matrix.md).

--- a/archive/gen_config_schema.py
+++ b/archive/gen_config_schema.py
@@ -1,3 +1,4 @@
+# DEPRECATED: Use CLI command `generate-default-config` instead
 # Utility script to generate a sample ProjectConfig YAML.
 # Not used in runtime – useful for onboarding and CI.
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -60,6 +60,14 @@ To compare corpus profiles use:
 ```bash
 python CorpusBuilderApp/cli.py diff-corpus --profile-a snapshot1.json --profile-b snapshot2.json
 ```
+Generate a template configuration:
+```bash
+python CorpusBuilderApp/cli.py generate-default-config --output config.yaml
+```
+Sync extractor domains with the balancer reference:
+```bash
+python CorpusBuilderApp/cli.py sync-domain-config --config config/balancer_config.yaml
+```
 You can run collectors, processors and the corpus balancer headlessly with
 `cli/execute_from_config.py`:
 ```bash


### PR DESCRIPTION
## Summary
- add `sync-domain-config` subcommand
- expose template config generation via `generate-default-config`
- move `gen_config_schema.py` to `archive` and mark deprecated
- document new commands in README and user guide

## Testing
- `pytest -q` *(fails: AttributeError in collectors and performance tests)*

------
https://chatgpt.com/codex/tasks/task_e_684864b5424883269b64e8a3ab431395