### PR TITLE
Remove unused and duplicate imports

### DIFF
--- a/CorpusBuilderApp/app/main_window.py
+++ b/CorpusBuilderApp/app/main_window.py
@@ -14,19 +14,11 @@ from PySide6.QtWidgets import (
     QLabel,
     QSplitter,
     QMessageBox,
-    QHBoxLayout,
-    QPushButton,
     QMenu,
-    QDialog,
-    QLineEdit,
-    QComboBox,
-    QTableWidget,
-    QTableWidgetItem,
-    QHeaderView,
     QFileDialog,
 )
-from PySide6.QtCore import Qt, QTimer, Signal as pyqtSignal, QThread, QSize
-from PySide6.QtGui import QAction, QIcon, QPixmap
+from PySide6.QtCore import Qt, QTimer, Signal as pyqtSignal, QThread
+from PySide6.QtGui import QAction, QIcon
 import logging
 from pathlib import Path
 import shutil

--- a/CorpusBuilderApp/app/ui/dialogs/api_key_dialog.py
+++ b/CorpusBuilderApp/app/ui/dialogs/api_key_dialog.py
@@ -1,8 +1,20 @@
 # File: app/ui/dialogs/api_key_dialog.py
 
-from PySide6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel, 
-                             QLineEdit, QPushButton, QFormLayout, QDialogButtonBox,
-                             QCheckBox, QComboBox, QTabWidget, QWidget)
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QFormLayout,
+    QDialogButtonBox,
+    QCheckBox,
+    QComboBox,
+    QTabWidget,
+    QWidget,
+    QMessageBox,
+)
 from PySide6.QtCore import Qt, Signal as pyqtSignal, Slot as pyqtSlot
 
 class APIKeyDialog(QDialog):
@@ -164,7 +176,6 @@ class APIKeyDialog(QDialog):
     def accept(self):
         """Handle dialog acceptance."""
         if not self.encrypt_keys.isChecked() and not self.use_env_file.isChecked():
-            from PySide6.QtWidgets import QMessageBox
             QMessageBox.warning(
                 self,
                 "Security Warning",
@@ -177,8 +188,6 @@ class APIKeyDialog(QDialog):
     
     def test_connections(self):
         """Test connections to APIs."""
-        from PySide6.QtWidgets import QMessageBox
-        
         # In a real implementation, this would test the actual APIs
         # For now, just show a message
         QMessageBox.information(

--- a/CorpusBuilderApp/app/ui/widgets/file_browser.py
+++ b/CorpusBuilderApp/app/ui/widgets/file_browser.py
@@ -305,7 +305,6 @@ class FileBrowser(QWidget):
     def open_file(self, file_path):
         """Open file with default application."""
         from PySide6.QtGui import QDesktopServices
-        from PySide6.QtCore import QUrl
         QDesktopServices.openUrl(QUrl.fromLocalFile(file_path))
         
     def copy_path_to_clipboard(self, file_path):


### PR DESCRIPTION
## Summary
- trim unused Qt widgets and classes in main window
- consolidate `QMessageBox` import at top of API key dialog
- clean up duplicate `QUrl` import in file browser

## Testing
- `pytest -q` *(fails: AttributeError in fred_collector, AttributeError in test_performance, AssertionError in test_run_collectors_from_config)*

------
https://chatgpt.com/codex/tasks/task_e_68486838b8dc8326b27f769d04550b7f