### PR TITLE
feat: integrate check-corpus CLI + GUI + docs + tests

### DIFF
--- a/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/corpus_manager_tab.py
@@ -393,6 +393,12 @@ class CorpusManagerTab(QWidget):
         self.validate_metadata_cb = QCheckBox("Validate Metadata")
         other_buttons_layout.addWidget(self.validate_metadata_cb)
 
+        self.auto_fix_cb = QCheckBox("Auto-fix missing folders")
+        other_buttons_layout.addWidget(self.auto_fix_cb)
+
+        self.check_integrity_cb = QCheckBox("Run corruption check")
+        other_buttons_layout.addWidget(self.check_integrity_cb)
+
         self.validate_structure_btn = QPushButton("Validate Structure")
         self.validate_structure_btn.clicked.connect(self.validate_corpus_structure)
         other_buttons_layout.addWidget(self.validate_structure_btn)
@@ -918,7 +924,9 @@ class CorpusManagerTab(QWidget):
     def validate_corpus_structure(self) -> None:
         """Trigger corpus structure validation via the service."""
         self.validator_service.validate_structure(
-            validate_metadata=self.validate_metadata_cb.isChecked()
+            validate_metadata=self.validate_metadata_cb.isChecked(),
+            auto_fix=self.auto_fix_cb.isChecked(),
+            check_integrity=self.check_integrity_cb.isChecked(),
         )
 
     def show_validation_results(self, results: dict) -> None:

--- a/CorpusBuilderApp/cli.py
+++ b/CorpusBuilderApp/cli.py
@@ -41,6 +41,7 @@ CLI Command          | GUI Equivalent
 --collector web      | Collectors -> General Web
 diff-corpus          | Tools -> Diff Corpus Profiles
 export-corpus        | Tools -> Export Corpus
+check-corpus         | Tools -> Validate Corpus
 """
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
@@ -157,16 +158,16 @@ def main(argv: list[str] | None = None) -> int:
             help="Sample files with CorruptionDetector",
         )
         chk_args = check_parser.parse_args(argv[1:])
-        from tools import check_corpus_structure
+        from tools.check_corpus_structure import check_corpus_structure
+        from shared_tools.project_config import ProjectConfig
 
-        call_args = ["--config", chk_args.config]
-        if chk_args.validate_metadata:
-            call_args.append("--validate-metadata")
-        if chk_args.auto_fix:
-            call_args.append("--auto-fix")
-        if chk_args.check_integrity:
-            call_args.append("--check-integrity")
-        check_corpus_structure.main(call_args)
+        config = ProjectConfig.from_yaml(chk_args.config)
+        check_corpus_structure(
+            config,
+            validate_metadata=chk_args.validate_metadata,
+            auto_fix=chk_args.auto_fix,
+            check_integrity=chk_args.check_integrity,
+        )
         return 0
 
     if argv and argv[0] == "import-corpus":

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ python CorpusBuilderApp/cli.py export-corpus --corpus-dir data/corpus \
     --output-dir exports --dry-run
 ```
 
+### Example Commands
+```bash
+python CorpusBuilderApp/cli.py check-corpus --config config.yaml --auto-fix
+```
+
 ## License
 
 This project is proprietary and all rights are reserved by Bored AI Labs.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -129,6 +129,21 @@ Use **Tools → Import Corpus** to load a previously exported ZIP archive. The s
   `--auto-fix` to create any missing directories and `--check-integrity` to
   scan sample files for corruption.
 
+### Validating the Corpus (CLI)
+
+You can validate your corpus structure via:
+
+```bash
+python CorpusBuilderApp/cli.py check-corpus --config config.yaml --validate-metadata --auto-fix --check-integrity
+```
+
+This command will:
+
+- Ensure required directories exist
+- Optionally create them (`--auto-fix`)
+- Check for file corruption (`--check-integrity`)
+- Validate metadata fields (`--validate-metadata`)
+
 ## Troubleshooting
 - If a configuration fails to load, check the YAML syntax and file paths.
 - Logs are stored in the directory defined by `logs_dir` in your configuration.

--- a/tests/data/sample_config.yaml
+++ b/tests/data/sample_config.yaml
@@ -1,0 +1,6 @@
+directories:
+  corpus_root: ./tests/tmp_corpus
+  raw_data_dir: ./tests/tmp_corpus/raw
+  processed_dir: ./tests/tmp_corpus/processed
+  metadata_dir: ./tests/tmp_corpus/metadata
+  logs_dir: ./tests/tmp_corpus/logs

--- a/tests/unit/test_check_corpus_cli.py
+++ b/tests/unit/test_check_corpus_cli.py
@@ -1,0 +1,50 @@
+import sys
+import types
+
+# Stub heavy modules before importing CLI
+for mod in [
+    "pandas",
+    "numpy",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "seaborn",
+    "plotly",
+    "plotly.subplots",
+    "plotly.graph_objects",
+    "plotly.express",
+    "requests",
+    "yaml",
+]:
+    sys.modules.setdefault(mod, types.ModuleType(mod))
+
+from CorpusBuilderApp import cli  # noqa: E402
+
+
+def test_check_corpus(monkeypatch):
+    called = {}
+
+    def fake_check(config, validate_metadata, auto_fix, check_integrity):
+        called.update({
+            "validate_metadata": validate_metadata,
+            "auto_fix": auto_fix,
+            "check_integrity": check_integrity,
+        })
+
+    monkeypatch.setattr(
+        "tools.check_corpus_structure.check_corpus_structure", fake_check
+    )
+
+    test_args = [
+        "check-corpus",
+        "--config",
+        "tests/data/sample_config.yaml",
+        "--validate-metadata",
+        "--auto-fix",
+        "--check-integrity",
+    ]
+
+    cli.main(test_args)
+
+    assert called["validate_metadata"]
+    assert called["auto_fix"]
+    assert called["check_integrity"]


### PR DESCRIPTION
## Summary
- wire `check-corpus` subcommand through CLI using `check_corpus_structure`
- show `check-corpus` parity with GUI
- expose auto-fix and corruption check options in GUI
- document corpus validation usage
- include CLI example in README
- unit test for `check-corpus` command

## Testing
- `pytest -m "not optional_dependency" tests/unit tests/cli -q`

------
https://chatgpt.com/codex/tasks/task_e_68486c44a6688326a1e89fd713a8f50f