### PR TITLE
feat(cli): add CLI help, fix import-corpus import, test generate-default-config

### DIFF
--- a/CorpusBuilderApp/cli.py
+++ b/CorpusBuilderApp/cli.py
@@ -98,6 +98,19 @@ def cmd_diff_corpus(args: argparse.Namespace) -> int:
 def main(argv: list[str] | None = None) -> int:
     argv = list(argv) if argv is not None else sys.argv[1:]
 
+    if not argv or "--help" in argv:
+        print("Available CLI commands:")
+        print("  generate-default-config --output config.yaml")
+        print("  diff-corpus --profile-a file.json --profile-b file.json")
+        print("  export-corpus --corpus-dir path --output-dir path")
+        print(
+            "  check-corpus --config file.yaml [--auto-fix] [--validate-metadata] [--check-integrity]"
+        )
+        print("  import-corpus --source-dir path --config file.yaml")
+        print("  --matrix     Show CLI/GUI feature parity")
+        print("  --version    Show current version")
+        return 0
+
     if "--version" in argv:
         print(__version__)
         return 0
@@ -180,7 +193,7 @@ def main(argv: list[str] | None = None) -> int:
         args = parser.parse_args(argv[1:])
 
         from tools.check_corpus_structure import check_corpus_structure
-        from shared_tools.config.project_config import ProjectConfig
+        from shared_tools.project_config import ProjectConfig
         import shutil
 
         cfg = ProjectConfig.from_yaml(args.config)

--- a/tests/unit/test_generate_default_config_cli.py
+++ b/tests/unit/test_generate_default_config_cli.py
@@ -1,0 +1,40 @@
+import sys
+import types
+import yaml
+import json
+from pathlib import Path
+
+# Stub heavy modules before importing CLI
+for mod in [
+    "pandas",
+    "numpy",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "seaborn",
+    "plotly",
+    "plotly.subplots",
+    "plotly.graph_objects",
+    "plotly.express",
+    "requests",
+    "yaml",
+]:
+    sys.modules.setdefault(mod, types.ModuleType(mod))
+
+from CorpusBuilderApp import cli  # noqa: E402
+
+
+def test_generate_default_config(tmp_path: Path, monkeypatch):
+    out_file = tmp_path / "cfg.yaml"
+    monkeypatch.setattr(
+        yaml,
+        "safe_dump",
+        lambda data, fh, sort_keys=False: fh.write(json.dumps(data)),
+    )
+    monkeypatch.setattr(yaml, "safe_load", lambda text: json.loads(text))
+    result = cli.main(["generate-default-config", "--output", str(out_file)])
+    assert result == 0
+    assert out_file.exists()
+    data = yaml.safe_load(out_file.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    assert "environment" in data
+


### PR DESCRIPTION
## Summary
- show top-level help if no args
- fix ProjectConfig import path in `import-corpus`
- add missing unit test for `generate-default-config`

## Testing
- `pytest tests/unit/test_generate_default_config_cli.py tests/unit/test_diff_corpus_cli.py tests/unit/test_check_corpus_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68486e54cba483268f8d4eef36f67a69