### PR TITLE
Fix CLI ProjectConfig import

### DIFF
--- a/CorpusBuilderApp/cli.py
+++ b/CorpusBuilderApp/cli.py
@@ -180,7 +180,7 @@ def main(argv: list[str] | None = None) -> int:
         args = parser.parse_args(argv[1:])
 
         from tools.check_corpus_structure import check_corpus_structure
-        from shared_tools.config.project_config import ProjectConfig
+        from shared_tools.project_config import ProjectConfig
         import shutil
 
         cfg = ProjectConfig.from_yaml(args.config)


### PR DESCRIPTION
## Summary
- use new `shared_tools.project_config` path in CLI

## Testing
- `pytest -q` *(fails: AttributeError in fred_collector, performance tests, collectors from config)*

------
https://chatgpt.com/codex/tasks/task_e_68486f4104ec8326ae9a99d7c712193a