### PR TITLE
Handle --help in CLI main

### DIFF
--- a/CorpusBuilderApp/cli.py
+++ b/CorpusBuilderApp/cli.py
@@ -106,6 +106,20 @@ def main(argv: list[str] | None = None) -> int:
         print(PARITY_TABLE)
         return 0
 
+    SUPPORTED_COMMANDS = [
+        "generate-default-config",
+        "diff-corpus",
+        "export-corpus",
+        "check-corpus",
+        "import-corpus",
+        "sync-domain-config",
+        "sync-config",
+    ]
+
+    if not argv or "--help" in argv:
+        print("Supported commands: " + ", ".join(SUPPORTED_COMMANDS))
+        return 0
+
     if argv and argv[0] == "diff-corpus":
         diff_parser = argparse.ArgumentParser(prog="diff-corpus", description="Compare two corpus profiles")
         diff_parser.add_argument("--profile-a", required=True, help="Path to first corpus profile JSON")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,7 +218,10 @@ setattr(pydantic_mod, 'field_validator', lambda *a, **k: (lambda f: f))
 setattr(pydantic_mod, 'Field', lambda *a, **k: None)
 setattr(pydantic_mod, 'ValidationError', type('ValidationError', (Exception,), {}))
 
+import importlib.machinery
+
 psutil_mod = sys.modules.setdefault('psutil', types.ModuleType('psutil'))
+setattr(psutil_mod, '__spec__', importlib.machinery.ModuleSpec('psutil', loader=None))
 setattr(psutil_mod, 'Process', lambda *a, **k: None)
 
 if "langdetect" not in sys.modules:

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -1,0 +1,35 @@
+import sys
+import types
+
+# Stub heavy modules before importing CLI
+for mod in [
+    "pandas",
+    "numpy",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "seaborn",
+    "plotly",
+    "plotly.subplots",
+    "plotly.graph_objects",
+    "plotly.express",
+    "requests",
+    "yaml",
+]:
+    sys.modules.setdefault(mod, types.ModuleType(mod))
+
+from CorpusBuilderApp import cli  # noqa: E402
+
+
+def test_help_message_empty_args(capsys):
+    exit_code = cli.main([])
+    out = capsys.readouterr().out
+    assert "generate-default-config" in out
+    assert "diff-corpus" in out
+    assert exit_code == 0
+
+
+def test_help_message_flag(capsys):
+    exit_code = cli.main(["--help"])
+    out = capsys.readouterr().out
+    assert "export-corpus" in out
+    assert exit_code == 0


### PR DESCRIPTION
## Summary
- add early help handling in CLI
- fix psutil stub so pytest can import it
- test help output when no args or `--help` flag

## Testing
- `pytest -q tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_68486f3df6ac8326820d6904c0f6a035