### PR TITLE
Improve progress feedback in CryptoCorpusBuilder

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -47,6 +47,8 @@ You can drag this file onto the **Configuration** tab or load it via the menu. T
 - **Processors** – run batch processors on downloaded files.
 - **Corpus Manager** – browse and edit corpus contents.
 - **Balancer** – rebalance the corpus to match target allocations.
+- During rebalancing and corpus validation, a progress dialog shows task status
+  and the action buttons are disabled until the job completes.
 - **Analytics** – view statistics and keyword trends.
 - **Logs** – monitor activity and errors.
 The status bar displays queue information so you can track running tasks.


### PR DESCRIPTION
## Summary
- show progress dialogs during corpus validation and rebalancing
- log and notify when each domain is rebalanced
- disable UI buttons until operations finish
- document new dialogs in the user guide

## Testing
- `pytest -q` *(fails: AttributeError in tests due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_684870073d9883268d5604d4f635ccf1