### PR TITLE
Add CLI test for generating default config

### DIFF
--- a/tests/unit/test_generate_default_config_cli.py
+++ b/tests/unit/test_generate_default_config_cli.py
@@ -1,0 +1,40 @@
+import sys
+import types
+
+# Stub heavy modules before importing CLI
+for mod in [
+    "pandas",
+    "numpy",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "seaborn",
+    "plotly",
+    "plotly.subplots",
+    "plotly.graph_objects",
+    "plotly.express",
+    "requests",
+    "yaml",
+]:
+    sys.modules.setdefault(mod, types.ModuleType(mod))
+
+import importlib  # noqa: E402
+import CorpusBuilderApp.cli as cli  # noqa: E402
+
+
+def test_generate_default_config(tmp_path):
+    cfg_path = tmp_path / "cfg.yaml"
+
+    # Restore real PyYAML functions for this test
+    sys.modules.pop("yaml", None)
+    real_yaml = importlib.import_module("yaml")
+    sys.modules["yaml"] = real_yaml
+
+    exit_code = cli.main(
+        ["generate-default-config", "--output", str(cfg_path)]
+    )
+    assert exit_code == 0
+    assert cfg_path.exists()
+    with open(cfg_path, "r", encoding="utf-8") as fh:
+        data = real_yaml.safe_load(fh)
+    assert isinstance(data, dict)
+    assert "environment" in data


### PR DESCRIPTION
## Summary
- test generate-default-config CLI command

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_generate_default_config_cli.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68486f3f5f008326a35c95d66acad3ac