### PR TITLE
Add tooltips showing domain counts in pie charts

### DIFF
--- a/CorpusBuilderApp/app/helpers/chart_manager.py
+++ b/CorpusBuilderApp/app/helpers/chart_manager.py
@@ -95,7 +95,7 @@ class ChartManager:
         series = QPieSeries()
         
         for i, (label, value) in enumerate(data.items()):
-            slice_obj = series.append(f"{label} ({value:.1f}%)", value)
+            slice_obj = series.append(label, value)
             slice_obj.setLabelVisible(True)
             
             # Apply consistent colors
@@ -115,6 +115,17 @@ class ChartManager:
                 slice_obj.setLabelColor(QColor(255, 255, 255))  # Pure white for dark theme
             else:
                 slice_obj.setLabelColor(QColor(0, 0, 0))        # Pure black for light theme
+
+            # Attach count and percentage details to label and tooltip
+            domain_count = slice_obj.property("domain_count")
+            pct = round(slice_obj.percentage() * 100, 1)
+            slice_label = slice_obj.label()
+            slice_obj.setLabel(f"{slice_label} ({pct}%)")
+            if domain_count is not None:
+                tooltip = f"{slice_label}:\n{domain_count} documents\n{pct}% of corpus"
+            else:
+                tooltip = f"{slice_label}:\n{pct}% of corpus"
+            slice_obj.setToolTip(tooltip)
         
         chart.addSeries(series)
         

--- a/CorpusBuilderApp/app/ui/tabs/analytics_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/analytics_tab.py
@@ -247,6 +247,7 @@ class AnalyticsTab(QWidget):
         for i, domain in enumerate(domains):
             count = counts.get(domain, 0)
             slice_obj = series.append(f"{domain}", count)
+            slice_obj.setProperty("domain_count", count)
             slice_obj.setColor(palette[i % len(palette)])
             slice_obj.setLabelVisible(False)
             slice_obj.setBorderColor(QColor("#0f1419"))

--- a/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/dashboard_tab.py
@@ -230,8 +230,10 @@ class DashboardTab(QWidget):
         chart.setMargins(QMargins(0, 0, 0, 0))
         colors = ['#22c55e', '#32B8C6', '#E68161', '#8b5cf6', '#f59e0b', '#ef4444', '#06b6d4', '#9ca3af']
         series = QPieSeries()
+        counts = self.stats_service.get_domain_summary()
         for i, (domain, percentage) in enumerate(domain_data.items()):
             slice_obj = series.append(f'{domain[:12]}', percentage)
+            slice_obj.setProperty("domain_count", counts.get(domain, 0))
             color = colors[i % len(colors)]
             slice_obj.setBrush(QColor(color))
             slice_obj.setBorderColor(QColor('#1a1f2e'))
@@ -1027,8 +1029,10 @@ class DashboardTab(QWidget):
         chart.setMargins(QMargins(0, 0, 0, 0))
         colors = ['#22c55e', '#32B8C6', '#E68161', '#8b5cf6', '#f59e0b', '#ef4444', '#06b6d4', '#9ca3af']
         series = QPieSeries()
+        counts = self.stats_service.get_domain_summary()
         for i, (domain, percentage) in enumerate(domain_data.items()):
             slice_obj = series.append(f'{domain[:15]}', percentage)
+            slice_obj.setProperty("domain_count", counts.get(domain, 0))
             color = colors[i % len(colors)]
             slice_obj.setBrush(QColor(color))
             slice_obj.setBorderColor(QColor('#1a1f2e'))
@@ -1114,8 +1118,10 @@ class DashboardTab(QWidget):
         chart.setMargins(QMargins(0, 0, 0, 0))
         colors = ['#22c55e', '#32B8C6', '#E68161', '#8b5cf6', '#f59e0b', '#ef4444', '#06b6d4', '#9ca3af']
         series = QPieSeries()
+        counts = self.stats_service.get_domain_summary()
         for i, (domain, percentage) in enumerate(domain_data.items()):
             slice_obj = series.append(f'{domain[:6]}', percentage)
+            slice_obj.setProperty("domain_count", counts.get(domain, 0))
             color = colors[i % len(colors)]
             slice_obj.setBrush(QColor(color))
             slice_obj.setBorderColor(QColor('#1a1f2e'))

--- a/CorpusBuilderApp/app/ui/tabs/full_activity_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/full_activity_tab.py
@@ -608,6 +608,7 @@ class FullActivityTab(QWidget):
         
         for status, count in status_counts.items():
             slice_obj = series.append(f"{status.title()} ({count})", count)
+            slice_obj.setProperty("domain_count", count)
             if status in colors:
                 slice_obj.setBrush(QColor(colors[status]))
             


### PR DESCRIPTION
## Summary
- enhance `create_pie_chart` to read `domain_count` and show percentages
- include `domain_count` property when building pie charts in Dashboard, Analytics and Activity tabs

## Testing
- `pytest -q` *(fails: AttributeError in FREDCollector and memory_info)*

------
https://chatgpt.com/codex/tasks/task_e_684871c9bdc083268f4eedbe4d879606