### PR TITLE
Add stats help line

### DIFF
--- a/CorpusBuilderApp/cli.py
+++ b/CorpusBuilderApp/cli.py
@@ -107,6 +107,7 @@ def main(argv: list[str] | None = None) -> int:
             "  check-corpus --config file.yaml [--auto-fix] [--validate-metadata] [--check-integrity]"
         )
         print("  import-corpus --source-dir path --config file.yaml")
+        print("  stats --config file.yaml     Show domain stats in console")
         print("  --matrix     Show CLI/GUI feature parity")
         print("  --version    Show current version")
         return 0


### PR DESCRIPTION
## Summary
- print stats command in CorpusBuilderApp CLI help

## Testing
- `ruff check CorpusBuilderApp/cli.py`
- `PYTEST_QT_STUBS=1 pytest -m "not skip" -q`

------
https://chatgpt.com/codex/tasks/task_e_684871ca2f808326a3db19b77edd472f