### PR TITLE
Update ProjectConfig tests for new environment format

### DIFF
--- a/CorpusBuilderApp/tests/unit/test_project_config_public.py
+++ b/CorpusBuilderApp/tests/unit/test_project_config_public.py
@@ -5,13 +5,12 @@ import pytest
 
 
 def _write_yaml(path, corpus_dir):
+    """Write a minimal configuration file matching the current schema."""
     data = {
-        'environment': 'test',
-        'environments': {
-            'test': {'corpus_dir': str(corpus_dir)}
-        }
+        "environment": {"active": "test"},
+        "environments": {"test": {"corpus_dir": str(corpus_dir)}},
     }
-    with open(path, 'w') as f:
+    with open(path, "w") as f:
         yaml.safe_dump(data, f)
 
 
@@ -24,6 +23,7 @@ def test_from_yaml_and_getters(tmp_path, monkeypatch):
     monkeypatch.setenv('METADATA_DIR', str(corpus_root / 'metadata'))
     monkeypatch.setenv('LOGS_DIR', str(corpus_root / 'logs'))
     cfg = ProjectConfig.from_yaml(str(tmp_path / 'cfg.yaml'))
+    assert cfg.get('environment.active') == 'test'
     assert cfg.get_corpus_root() == corpus_root
     assert cfg.get_corpus_dir() == corpus_root
     assert cfg.get_raw_dir() == corpus_root / 'raw'


### PR DESCRIPTION
## Summary
- adapt unit test config helper to write environment as a dict
- assert the active environment in tests
- add `EnvironmentSettings` model and update schema
- keep defaults like `domains` when revalidating

## Testing
- `PYTEST_QT_STUBS=1 pytest CorpusBuilderApp/tests/unit/test_project_config_public.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848915352e883269d3651cac54fb2cd