### PR TITLE
Integrate EnvironmentSettings model

### DIFF
--- a/CorpusBuilderApp/app/main.py
+++ b/CorpusBuilderApp/app/main.py
@@ -156,7 +156,12 @@ class CryptoCorpusApp(QApplication):
         config_path = config_dir / "config.yaml"
         
         default_config = {
-            'environment': 'test',
+            'environment': {
+                'active': 'test',
+                'python_path': '',
+                'venv_path': '',
+                'temp_dir': ''
+            },
             'environments': {
                 'test': {
                     'corpus_dir': str(config_dir / 'corpus'),

--- a/CorpusBuilderApp/app/ui/dialogs/settings_dialog.py
+++ b/CorpusBuilderApp/app/ui/dialogs/settings_dialog.py
@@ -242,10 +242,13 @@ class SettingsDialog(QDialog):
         # General tab
         env_setting = self.current_settings.get('environment', 'test')
         if isinstance(env_setting, dict):
-            env_setting = 'test'  # Default to test if we got a dict
-        self.env_selector.setCurrentText(env_setting)
-        self.python_path.setText(self.current_settings.get('python_path', ''))
-        self.venv_path.setText('venv/')
+            self.env_selector.setCurrentText(env_setting.get('active', 'test'))
+            self.python_path.setText(env_setting.get('python_path', ''))
+            self.venv_path.setText(env_setting.get('venv_path', 'venv/'))
+        else:
+            self.env_selector.setCurrentText(env_setting)
+            self.python_path.setText(self.current_settings.get('python_path', ''))
+            self.venv_path.setText('venv/')
         self.theme_selector.setCurrentText(self.current_settings.get('theme', 'System'))
         self.show_tooltips.setChecked(self.current_settings.get('show_tooltips', True))
         self.auto_refresh.setChecked(self.current_settings.get('auto_refresh', True))
@@ -273,9 +276,11 @@ class SettingsDialog(QDialog):
         """Get the settings from the dialog."""
         return {
             # General
-            'environment': self.env_selector.currentText(),
-            'python_path': self.python_path.text(),
-            'venv_path': self.venv_path.text(),
+            'environment': {
+                'active': self.env_selector.currentText(),
+                'python_path': self.python_path.text(),
+                'venv_path': self.venv_path.text(),
+            },
             'theme': self.theme_selector.currentText(),
             'show_tooltips': self.show_tooltips.isChecked(),
             'auto_refresh': self.auto_refresh.isChecked(),

--- a/CorpusBuilderApp/shared_tools/project_config.py
+++ b/CorpusBuilderApp/shared_tools/project_config.py
@@ -225,6 +225,8 @@ class ProjectConfig:
         # Load configuration
         self.config = self._load_yaml_and_env_merge()
         self.revalidate()
+        # Ensure legacy attribute remains consistent
+        self.environment = self.get("environment.active")
         
     def _load_yaml_and_env_merge(self) -> Dict[str, Any]:
         """Load configuration from YAML and merge environment variables."""
@@ -234,6 +236,15 @@ class ProjectConfig:
         if self.config_path.exists():
             with open(self.config_path, 'r') as f:
                 config = yaml.safe_load(f)
+
+        # Convert legacy environment format
+        if isinstance(config.get('environment'), str):
+            config['environment'] = {
+                'active': config['environment'],
+                'python_path': '',
+                'venv_path': '',
+                'temp_dir': ''
+            }
         
         # Override with environment variables
         env_config = {

--- a/CorpusBuilderApp/tests/integration/test_multi_collector_flow.py
+++ b/CorpusBuilderApp/tests/integration/test_multi_collector_flow.py
@@ -12,7 +12,7 @@ from shared_tools.collectors.github_collector import GitHubCollector
 
 def _write_yaml(path: Path, corpus_dir: Path) -> None:
     data = {
-        "environment": "test",
+        "environment": {"active": "test"},
         "environments": {"test": {"corpus_dir": str(corpus_dir)}},
     }
     with open(path, "w", encoding="utf-8") as fh:

--- a/CorpusBuilderApp/tests/integration/test_project_config_edges.py
+++ b/CorpusBuilderApp/tests/integration/test_project_config_edges.py
@@ -61,7 +61,7 @@ from app.ui.dialogs.settings_dialog import SettingsDialog
 
 def _write_yaml(path: Path, corpus_dir: Path) -> None:
     data = {
-        "environment": "test",
+        "environment": {"active": "test"},
         "environments": {"test": {"corpus_dir": str(corpus_dir)}},
     }
     with open(path, "w", encoding="utf-8") as fh:

--- a/scripts/audit_integration_state.py
+++ b/scripts/audit_integration_state.py
@@ -231,7 +231,12 @@ def verify_project_config():
         tmpdir = tempfile.mkdtemp()
         cfg_path = Path(tmpdir) / "cfg.yaml"
         data = {
-            "environment": "test",
+            "environment": {
+                "active": "test",
+                "python_path": "",
+                "venv_path": "",
+                "temp_dir": "",
+            },
             "environments": {"test": {"corpus_dir": tmpdir}},
         }
         import yaml


### PR DESCRIPTION
## Summary
- support legacy `environment` string in `ProjectConfig`
- embed `EnvironmentSettings` when creating default configs
- adjust Settings dialog for new environment object
- update example YAML in tests and audit script

## Testing
- `pytest -q tests` *(fails: ModuleNotFoundError: 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684897e52a948326baea9d078e2b033b