### PR TITLE
Update config docs

### DIFF
--- a/docs/environment_config.md
+++ b/docs/environment_config.md
@@ -43,6 +43,6 @@ Only the variables relevant to your workflow need to be defined. If a value is o
 
 The active environment is controlled by the `ENVIRONMENT` variable. Set it to `test` or `production` in your `.env` file (or export it in the shell) before launching the application or running command-line tools. The GUI also exposes an environment selector in the **Configuration** tab that updates the same value.
 
-Different YAML configuration files can be used for each environment (for example `config/test.yaml` and `config/production.yaml`). Changing `ENVIRONMENT` ensures the appropriate configuration is loaded.
+Different YAML configuration files can be used for each environment (for example `config/test.yaml` and `config/production.yaml`). Changing `ENVIRONMENT` ensures the appropriate configuration is loaded. YAML configurations now use an `environment` key with an `environments` mapping for the directory paths, though old `directories:` blocks are still recognized for backward compatibility. Environment variables such as `CORPUS_ROOT` continue to override the respective paths defined in the YAML file.
 
 For automated tests or headless operation you can simply set `ENVIRONMENT=test`.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -27,19 +27,19 @@ python CorpusBuilderApp/app/main.py
 The application window will open with tabs for configuration, collection and processing.
 
 ## Creating or Loading a Configuration
-The application expects a YAML configuration describing collectors, processors and corpus directories. A minimal example:
+The application expects a YAML configuration describing collectors, processors and directories. The preferred layout uses an `environment` key and an `environments` mapping:
 ```yaml
-enabled_collectors:
-  - github
-enabled_processors:
-  - pdf
-directories:
-  corpus_root: ./data/corpus
-  raw_data_dir: ./data/raw
-  processed_dir: ./data/processed
-  metadata_dir: ./data/metadata
-  logs_dir: ./data/logs
+environment: production  # or "test"
+
+environments:
+  production:
+    corpus_root: ./data/corpus
+    raw_data_dir: ./data/raw
+    processed_dir: ./data/processed
+    metadata_dir: ./data/metadata
+    logs_dir: ./data/logs
 ```
+Legacy `directories:` blocks are still supported for backward compatibility, but they may be removed in a future release.
 You can drag this file onto the **Configuration** tab or load it via the menu. To use the same configuration from the command line, pass `--config path/to/file.yaml`.
 
 ## Using the App (GUI)


### PR DESCRIPTION
## Summary
- update YAML example in the user guide to the new `environments` layout
- document legacy `directories:` block support and environment variable overrides

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: nbformat)*

------
https://chatgpt.com/codex/tasks/task_e_68489e13a194832695031635478962a1