### PR TITLE
Support environment-specific directories in config UI

### DIFF
--- a/CorpusBuilderApp/app/ui/dialogs/settings_dialog.py
+++ b/CorpusBuilderApp/app/ui/dialogs/settings_dialog.py
@@ -253,12 +253,14 @@ class SettingsDialog(QDialog):
         self.show_tooltips.setChecked(self.current_settings.get('show_tooltips', True))
         self.auto_refresh.setChecked(self.current_settings.get('auto_refresh', True))
         
-        # Directories tab
-        self.corpus_root.setText(self.current_settings.get('corpus_root', ''))
-        self.raw_dir.setText(self.current_settings.get('raw_dir', ''))
-        self.processed_dir.setText(self.current_settings.get('processed_dir', ''))
-        self.metadata_dir.setText(self.current_settings.get('metadata_dir', ''))
-        self.logs_dir.setText(self.current_settings.get('logs_dir', ''))
+        # Directories tab - support new environment layout with legacy fallback
+        env = self.env_selector.currentText()
+        env_dirs = self.current_settings.get('environments', {}).get(env, {})
+        self.corpus_root.setText(env_dirs.get('corpus_root', self.current_settings.get('corpus_root', '')))
+        self.raw_dir.setText(env_dirs.get('raw_dir', self.current_settings.get('raw_dir', '')))
+        self.processed_dir.setText(env_dirs.get('processed_dir', self.current_settings.get('processed_dir', '')))
+        self.metadata_dir.setText(env_dirs.get('metadata_dir', self.current_settings.get('metadata_dir', '')))
+        self.logs_dir.setText(env_dirs.get('logs_dir', self.current_settings.get('logs_dir', '')))
         self.create_missing.setChecked(self.current_settings.get('create_missing_dirs', True))
         
         # Processing tab
@@ -274,25 +276,24 @@ class SettingsDialog(QDialog):
     
     def get_settings(self):
         """Get the settings from the dialog."""
+        env = self.env_selector.currentText()
         return {
             # General
-            'environment': {
-                'active': self.env_selector.currentText(),
-                'python_path': self.python_path.text(),
-                'venv_path': self.venv_path.text(),
-            },
+            'environment.active': env,
+            'environment.python_path': self.python_path.text(),
+            'environment.venv_path': self.venv_path.text(),
             'theme': self.theme_selector.currentText(),
             'show_tooltips': self.show_tooltips.isChecked(),
             'auto_refresh': self.auto_refresh.isChecked(),
-            
-            # Directories
-            'corpus_root': self.corpus_root.text(),
-            'raw_dir': self.raw_dir.text(),
-            'processed_dir': self.processed_dir.text(),
-            'metadata_dir': self.metadata_dir.text(),
-            'logs_dir': self.logs_dir.text(),
+
+            # Directories stored per-environment
+            f'environments.{env}.corpus_root': self.corpus_root.text(),
+            f'environments.{env}.raw_dir': self.raw_dir.text(),
+            f'environments.{env}.processed_dir': self.processed_dir.text(),
+            f'environments.{env}.metadata_dir': self.metadata_dir.text(),
+            f'environments.{env}.logs_dir': self.logs_dir.text(),
             'create_missing_dirs': self.create_missing.isChecked(),
-            
+
             # Processing
             'enable_ocr': self.enable_ocr.isChecked(),
             'pdf_threads': self.pdf_threads.value(),
@@ -303,7 +304,7 @@ class SettingsDialog(QDialog):
             'min_quality': self.min_quality.value(),
             'batch_size': self.batch_size.value(),
             'timeout': self.timeout.value(),
-            'sound_enabled': self.sound_checkbox.isChecked()
+            'sound_enabled': self.sound_checkbox.isChecked(),
         }
     
     def accept(self):

--- a/CorpusBuilderApp/app/ui/tabs/configuration_tab.py
+++ b/CorpusBuilderApp/app/ui/tabs/configuration_tab.py
@@ -426,12 +426,23 @@ class ConfigurationTab(QWidget):
         self.scidb_token.setText(self.project_config.get("api_keys.scidb", ""))
         self.web_token.setText(self.project_config.get("api_keys.web", ""))
 
-        # Load directories
-        self.corpus_root.setText(self.project_config.get("directories.corpus_root", ""))
-        self.raw_data_dir.setText(self.project_config.get("directories.raw_data", ""))
-        self.processed_dir.setText(self.project_config.get("directories.processed", ""))
-        self.metadata_dir.setText(self.project_config.get("directories.metadata", ""))
-        self.logs_dir.setText(self.project_config.get("directories.logs", ""))
+        # Load directories from the active environment
+        env_dirs = self.project_config.get(f"environments.{env}", {})
+        self.corpus_root.setText(
+            env_dirs.get("corpus_root", self.project_config.get("directories.corpus_root", ""))
+        )
+        self.raw_data_dir.setText(
+            env_dirs.get("raw_dir", self.project_config.get("directories.raw_data", ""))
+        )
+        self.processed_dir.setText(
+            env_dirs.get("processed_dir", self.project_config.get("directories.processed", ""))
+        )
+        self.metadata_dir.setText(
+            env_dirs.get("metadata_dir", self.project_config.get("directories.metadata", ""))
+        )
+        self.logs_dir.setText(
+            env_dirs.get("logs_dir", self.project_config.get("directories.logs", ""))
+        )
 
         # Load domains
         domains = self.project_config.get("domains", {})
@@ -503,12 +514,23 @@ class ConfigurationTab(QWidget):
             self.project_config.set("api_keys.scidb", self.scidb_token.text())
             self.project_config.set("api_keys.web", self.web_token.text())
 
-            # Save directories
-            self.project_config.set("directories.corpus_root", self.corpus_root.text())
-            self.project_config.set("directories.raw_data", self.raw_data_dir.text())
-            self.project_config.set("directories.processed", self.processed_dir.text())
-            self.project_config.set("directories.metadata", self.metadata_dir.text())
-            self.project_config.set("directories.logs", self.logs_dir.text())
+            # Save directories under the active environment
+            env = self.env_selector.currentText()
+            self.project_config.set(
+                f"environments.{env}.corpus_root", self.corpus_root.text()
+            )
+            self.project_config.set(
+                f"environments.{env}.raw_dir", self.raw_data_dir.text()
+            )
+            self.project_config.set(
+                f"environments.{env}.processed_dir", self.processed_dir.text()
+            )
+            self.project_config.set(
+                f"environments.{env}.metadata_dir", self.metadata_dir.text()
+            )
+            self.project_config.set(
+                f"environments.{env}.logs_dir", self.logs_dir.text()
+            )
 
             # Save domains
             domains = self.validate_domain_config()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,78 @@ if os.environ.get("PYTEST_QT_STUBS") == "1":
 
     qtwidgets = _SafeStubModule("PySide6.QtWidgets")
 
+    class _Widget:
+        def __init__(self, *a, **k):
+            pass
+
+        def setAcceptDrops(self, *a, **k):
+            pass
+
+        def setWindowTitle(self, *a, **k):
+            pass
+
+    for name in [
+        "QWidget",
+        "QDialog",
+        "QGroupBox",
+        "QFrame",
+        "QFileDialog",
+        "QScrollArea",
+        "QMenu",
+    ]:
+        qtwidgets.__dict__[name] = type(name, (), {
+            "__init__": _Widget.__init__,
+            "setAcceptDrops": _Widget.setAcceptDrops,
+            "setWindowTitle": _Widget.setWindowTitle,
+        })
+
+    for name in [
+        "QPushButton",
+        "QLabel",
+        "QLineEdit",
+        "QComboBox",
+        "QTabWidget",
+        "QCheckBox",
+        "QFormLayout",
+        "QSpinBox",
+        "QTableWidget",
+        "QTableWidgetItem",
+        "QHeaderView",
+        "QDialogButtonBox",
+        "QDateEdit",
+    ]:
+        qtwidgets.__dict__[name] = type(name, (), {"__init__": _Widget.__init__})
+
+    for name in [
+        "QVBoxLayout",
+        "QHBoxLayout",
+        "QFormLayout",
+    ]:
+        qtwidgets.__dict__[name] = type(
+            name,
+            (),
+            {
+                "__init__": _Widget.__init__,
+                "addWidget": lambda *a, **k: None,
+                "addLayout": lambda *a, **k: None,
+                "addRow": lambda *a, **k: None,
+                "addStretch": lambda *a, **k: None,
+                "setContentsMargins": lambda *a, **k: None,
+                "setSpacing": lambda *a, **k: None,
+            },
+        )
+
+    class QMessageBox:
+        @staticmethod
+        def critical(*a, **k):
+            pass
+
+        @staticmethod
+        def information(*a, **k):
+            pass
+
+    qtwidgets.QMessageBox = QMessageBox
+
     class QApplication:
         _instance = None
 
@@ -211,6 +283,9 @@ class DummyBaseModel:
     @classmethod
     def parse_obj(cls, obj):
         return cls()
+
+    def dict(self, *a, **k):
+        return {}
 
 setattr(pydantic_mod, 'BaseModel', DummyBaseModel)
 setattr(pydantic_mod, 'validator', lambda *a, **k: (lambda f: f))

--- a/tests/ui/test_configuration_tab.py
+++ b/tests/ui/test_configuration_tab.py
@@ -81,7 +81,8 @@ def test_environment_change_auto_saved(monkeypatch, mock_project_config, tmp_pat
     assert ("environment.active", "production") in recorded
     assert saved
 
-def test_import_config_populates_fields(tmp_path, qtbot, mock_project_config):
+@pytest.mark.parametrize("use_old", [True, False])
+def test_import_config_populates_fields(tmp_path, qtbot, mock_project_config, use_old):
     cfg = _make_config(mock_project_config, tmp_path)
     tab = ConfigurationTab(cfg)
     qtbot.addWidget(tab)
@@ -93,9 +94,13 @@ def test_import_config_populates_fields(tmp_path, qtbot, mock_project_config):
             "python_path": "/usr/bin/python",
         },
         "api_keys": {"fred_key": "abc"},
-        "directories": {"corpus_root": "/data"},
         "processing": {"pdf": {"enable_ocr": False}},
     }
+    if use_old:
+        config_data["directories"] = {"corpus_root": "/data"}
+    else:
+        config_data["environments"] = {"production": {"corpus_root": "/data"}}
+
     config_file = tmp_path / "import.yaml"
     import yaml
     config_file.write_text(yaml.safe_dump(config_data))


### PR DESCRIPTION
## Summary
- enable per-environment directory handling in `ConfigurationTab`
- update `SettingsDialog` to persist directories under `environments.<env>`
- allow loading legacy configs while saving new layout
- adjust Qt stubs for tests
- test old and new configuration layouts

## Testing
- `PYTEST_QT_STUBS=1 pytest tests/ui/test_configuration_tab.py -q` *(fails: CardWrapper missing methods)*

------
https://chatgpt.com/codex/tasks/task_e_68489e0e234483268d2d8606f564d2e2